### PR TITLE
docs: badges + support section on every README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # 🧰 eigenwise-toolshed
 
+[![Claude Code](https://img.shields.io/badge/Claude_Code-plugin_marketplace-D97757?logo=claude&logoColor=white)](https://claude.com/claude-code)
+[![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](./LICENSE)
+[![No dependencies](https://img.shields.io/badge/dependencies-none,_Node_stdlib_only-brightgreen)](#install)
+[![Last commit](https://img.shields.io/github/last-commit/Eigenwise/eigenwise-toolshed)](https://github.com/Eigenwise/eigenwise-toolshed/commits/main)
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Eigenwise)
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
+[![GitHub stars](https://img.shields.io/github/stars/Eigenwise/eigenwise-toolshed?style=social)](https://github.com/Eigenwise/eigenwise-toolshed/stargazers)
+
 A small, growing marketplace of [Claude Code](https://claude.com/claude-code) plugins.
 
 > Sharp little tools for Claude Code, kept in one shed. 🛠️

--- a/examples/haiku-jar/README.md
+++ b/examples/haiku-jar/README.md
@@ -145,3 +145,7 @@ ruff check . && ruff format --check .
 
 The jar is written to `./haiku-jar.json` (override with `HAIKU_JAR_PATH`), and that
 file is git-ignored so running the tool never dirties the repo.
+
+---
+
+*Part of the [eigenwise-toolshed](../../README.md), free and MIT. If it helps you, [a coffee](https://ko-fi.com/eigenwise) or [a GitHub sponsorship](https://github.com/sponsors/Eigenwise) keeps the shed stocked.*

--- a/plugins/codebase-mapper/README.md
+++ b/plugins/codebase-mapper/README.md
@@ -1,5 +1,11 @@
 # codebase-mapper
 
+[![Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FEigenwise%2Feigenwise-toolshed%2Fmain%2Fplugins%2Fcodebase-mapper%2F.claude-plugin%2Fplugin.json&query=%24.version&label=version&color=blue)](.claude-plugin/plugin.json)
+[![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-D97757?logo=claude&logoColor=white)](https://claude.com/claude-code)
+[![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](../../LICENSE)
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Eigenwise)
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
+
 A self-maintaining **codebase map** for Claude Code: small Markdown docs under
 `.claude/.codebase-info/` that describe how your project is built, re-injected into context on every
 prompt so Claude starts each session already knowing the layout instead of grepping around blind.
@@ -107,6 +113,10 @@ Commit `.claude/.codebase-info/` so the whole team and every future session shar
 
 - Docs: delete `.claude/.codebase-info/`.
 - Plugin: `/plugin uninstall codebase-mapper@eigenwise-toolshed`.
+
+## Support
+
+codebase-mapper is free and MIT-licensed. If it saves you time, [a coffee](https://ko-fi.com/eigenwise) or [a GitHub sponsorship](https://github.com/sponsors/Eigenwise) genuinely helps me keep building and maintaining these tools.
 
 ## License
 

--- a/plugins/live-rules/README.md
+++ b/plugins/live-rules/README.md
@@ -1,5 +1,11 @@
 # live-rules
 
+[![Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FEigenwise%2Feigenwise-toolshed%2Fmain%2Fplugins%2Flive-rules%2F.claude-plugin%2Fplugin.json&query=%24.version&label=version&color=blue)](.claude-plugin/plugin.json)
+[![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-D97757?logo=claude&logoColor=white)](https://claude.com/claude-code)
+[![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](../../LICENSE)
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Eigenwise)
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
+
 **Developer-friendly, live rules for Claude Code.** Keep your rules in one Markdown file
 (`.claude/live-rules.md` by default, or anywhere you like), and a pair of bundled hooks re-inject the
 ones that apply, right when they apply: global rules and prompt-keyword rules on every prompt,
@@ -352,6 +358,10 @@ during a refactor and turn it back on later.
 
 - Rules: delete `.claude/live-rules.md` (or individual sections inside it).
 - Plugin: `/plugin uninstall live-rules@eigenwise-toolshed`.
+
+## Support
+
+live-rules is free and MIT-licensed. If it saves you time, [a coffee](https://ko-fi.com/eigenwise) or [a GitHub sponsorship](https://github.com/sponsors/Eigenwise) genuinely helps me keep building and maintaining these tools.
 
 ## License
 

--- a/plugins/sidequest/README.md
+++ b/plugins/sidequest/README.md
@@ -1,5 +1,11 @@
 # sidequest
 
+[![Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FEigenwise%2Feigenwise-toolshed%2Fmain%2Fplugins%2Fsidequest%2F.claude-plugin%2Fplugin.json&query=%24.version&label=version&color=blue)](.claude-plugin/plugin.json)
+[![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-D97757?logo=claude&logoColor=white)](https://claude.com/claude-code)
+[![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](../../LICENSE)
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Eigenwise)
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
+
 **A Trello-light quest log for Claude Code.** The stray issues you mention while Claude is busy with
 something else — *"oh, and the contact form doesn't send"* — get captured as **tickets** on the spot,
 with any image you pasted attached, and land on a **live, self-hosted Kanban dashboard** that spans
@@ -431,6 +437,10 @@ Two optional environment variables (set them in `.claude/settings.json` under `e
 - Tickets for one project: delete its folder under `~/.claude/sidequest/projects/`.
 - Everything: delete `~/.claude/sidequest/` (stop the server first with `… stop`).
 - Plugin: `/plugin uninstall sidequest@eigenwise-toolshed`.
+
+## Support
+
+sidequest is free and MIT-licensed. If it saves you time, [a coffee](https://ko-fi.com/eigenwise) or [a GitHub sponsorship](https://github.com/sponsors/Eigenwise) genuinely helps me keep building and maintaining these tools.
 
 ## License
 

--- a/plugins/switchboard/README.md
+++ b/plugins/switchboard/README.md
@@ -1,5 +1,11 @@
 # switchboard
 
+[![Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FEigenwise%2Feigenwise-toolshed%2Fmain%2Fplugins%2Fswitchboard%2F.claude-plugin%2Fplugin.json&query=%24.version&label=version&color=blue)](.claude-plugin/plugin.json)
+[![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-D97757?logo=claude&logoColor=white)](https://claude.com/claude-code)
+[![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](../../LICENSE)
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Eigenwise)
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
+
 **Score the task, not the model.** Claude scores each piece of work for complexity (1 to 10),
 switchboard turns that score into a model tier and a reasoning effort, and the work runs in a
 named executor subagent at exactly that tier. Nobody hand-picks models anymore: the score is the
@@ -146,6 +152,10 @@ change did.
 the routing alone, for anyone who wants the ladder without a board. The engine is shared **by
 copy**, not by dependency: each plugin carries its own `lib/ladder.js` and its own invariant
 tests, and each plugin's tests are the source of truth for changes to its copy.
+
+## Support
+
+switchboard is free and MIT-licensed. If it saves you time, [a coffee](https://ko-fi.com/eigenwise) or [a GitHub sponsorship](https://github.com/sponsors/Eigenwise) genuinely helps me keep building and maintaining these tools.
 
 ## License
 

--- a/plugins/workspace-init/README.md
+++ b/plugins/workspace-init/README.md
@@ -1,5 +1,11 @@
 # workspace-init
 
+[![Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FEigenwise%2Feigenwise-toolshed%2Fmain%2Fplugins%2Fworkspace-init%2F.claude-plugin%2Fplugin.json&query=%24.version&label=version&color=blue)](.claude-plugin/plugin.json)
+[![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-D97757?logo=claude&logoColor=white)](https://claude.com/claude-code)
+[![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](../../LICENSE)
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Eigenwise)
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
+
 One command to set up a Claude Code workspace for a project, new or existing. It runs a short
 interview, then writes a populated `.claude/`: a `settings.json` that enables the right plugins for
 your stack, a tailored `live-rules.md`, a codebase map, and a short note on how the project is meant to
@@ -84,6 +90,10 @@ merged into skills: a `commands/x.md` and a `skills/x/SKILL.md` both map to the 
 is already a slash command on its own. Shipping a thin command that just invokes a same-named skill is
 an anti-pattern: the two share a name, and in practice it left the skill's steps un-injected (the
 harness saw the name "already loaded" and skipped the body). So this plugin ships the skill only.
+
+## Support
+
+workspace-init is free and MIT-licensed. If it saves you time, [a coffee](https://ko-fi.com/eigenwise) or [a GitHub sponsorship](https://github.com/sponsors/Eigenwise) genuinely helps me keep building and maintaining these tools.
 
 ## License
 


### PR DESCRIPTION
Adds a shields.io badge row to the top of the root README and all five plugin READMEs (Claude Code, MIT license, a version badge that reads live from each plugin.json, GitHub Sponsors, Ko-fi; plus stars and last-commit on the root), and gives each plugin README the same Support section the root already had. The haiku-jar example gets a one-line footer instead of the full treatment.

Donation channels match atomic-agents and eigenwise.io: GitHub Sponsors `Eigenwise` + Ko-fi `eigenwise`. FUNDING.yml already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)