### PR TITLE
docs: add the Discord badge to every README badge row

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Last commit](https://img.shields.io/github/last-commit/Eigenwise/eigenwise-toolshed)](https://github.com/Eigenwise/eigenwise-toolshed/commits/main)
 [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Eigenwise)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
+[![Discord](https://img.shields.io/badge/chat-on_discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/J3W9b5AZJR)
 [![GitHub stars](https://img.shields.io/github/stars/Eigenwise/eigenwise-toolshed?style=social)](https://github.com/Eigenwise/eigenwise-toolshed/stargazers)
 
 A small, growing marketplace of [Claude Code](https://claude.com/claude-code) plugins.

--- a/plugins/codebase-mapper/README.md
+++ b/plugins/codebase-mapper/README.md
@@ -5,6 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](../../LICENSE)
 [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Eigenwise)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
+[![Discord](https://img.shields.io/badge/chat-on_discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/J3W9b5AZJR)
 
 A self-maintaining **codebase map** for Claude Code: small Markdown docs under
 `.claude/.codebase-info/` that describe how your project is built, re-injected into context on every

--- a/plugins/live-rules/README.md
+++ b/plugins/live-rules/README.md
@@ -5,6 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](../../LICENSE)
 [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Eigenwise)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
+[![Discord](https://img.shields.io/badge/chat-on_discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/J3W9b5AZJR)
 
 **Developer-friendly, live rules for Claude Code.** Keep your rules in one Markdown file
 (`.claude/live-rules.md` by default, or anywhere you like), and a pair of bundled hooks re-inject the

--- a/plugins/sidequest/README.md
+++ b/plugins/sidequest/README.md
@@ -5,6 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](../../LICENSE)
 [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Eigenwise)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
+[![Discord](https://img.shields.io/badge/chat-on_discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/J3W9b5AZJR)
 
 **A Trello-light quest log for Claude Code.** The stray issues you mention while Claude is busy with
 something else — *"oh, and the contact form doesn't send"* — get captured as **tickets** on the spot,

--- a/plugins/switchboard/README.md
+++ b/plugins/switchboard/README.md
@@ -5,6 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](../../LICENSE)
 [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Eigenwise)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
+[![Discord](https://img.shields.io/badge/chat-on_discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/J3W9b5AZJR)
 
 **Score the task, not the model.** Claude scores each piece of work for complexity (1 to 10),
 switchboard turns that score into a model tier and a reasoning effort, and the work runs in a

--- a/plugins/workspace-init/README.md
+++ b/plugins/workspace-init/README.md
@@ -5,6 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](../../LICENSE)
 [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Eigenwise)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
+[![Discord](https://img.shields.io/badge/chat-on_discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/J3W9b5AZJR)
 
 One command to set up a Claude Code workspace for a project, new or existing. It runs a short
 interview, then writes a populated `.claude/`: a `settings.json` that enables the right plugins for


### PR DESCRIPTION
Adds the Discord badge (same server as Atomic Agents) next to Sponsors/Ko-fi on the root and all five plugin READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)