### PR TITLE
docs: big Ko-fi + Sponsor buttons in every Support section

### DIFF
--- a/examples/haiku-jar/README.md
+++ b/examples/haiku-jar/README.md
@@ -149,3 +149,7 @@ file is git-ignored so running the tool never dirties the repo.
 ---
 
 *Part of the [eigenwise-toolshed](../../README.md), free and MIT. If it helps you, [a coffee](https://ko-fi.com/eigenwise) or [a GitHub sponsorship](https://github.com/sponsors/Eigenwise) keeps the shed stocked.*
+
+| Ko-fi | GitHub Sponsors |
+|:-----:|:---------------:|
+| <a href="https://ko-fi.com/eigenwise"><img height="32" alt="Support me on Ko-fi" src="https://ko-fi.com/img/githubbutton_sm.svg"></a> | <a href="https://github.com/sponsors/Eigenwise"><img height="32" alt="Sponsor on GitHub" src="https://img.shields.io/badge/Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white"></a> |

--- a/plugins/codebase-mapper/README.md
+++ b/plugins/codebase-mapper/README.md
@@ -119,6 +119,10 @@ Commit `.claude/.codebase-info/` so the whole team and every future session shar
 
 codebase-mapper is free and MIT-licensed. If it saves you time, [a coffee](https://ko-fi.com/eigenwise) or [a GitHub sponsorship](https://github.com/sponsors/Eigenwise) genuinely helps me keep building and maintaining these tools.
 
+| Ko-fi | GitHub Sponsors |
+|:-----:|:---------------:|
+| <a href="https://ko-fi.com/eigenwise"><img height="32" alt="Support me on Ko-fi" src="https://ko-fi.com/img/githubbutton_sm.svg"></a> | <a href="https://github.com/sponsors/Eigenwise"><img height="32" alt="Sponsor on GitHub" src="https://img.shields.io/badge/Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white"></a> |
+
 ## License
 
 MIT © Eigenwise

--- a/plugins/live-rules/README.md
+++ b/plugins/live-rules/README.md
@@ -364,6 +364,10 @@ during a refactor and turn it back on later.
 
 live-rules is free and MIT-licensed. If it saves you time, [a coffee](https://ko-fi.com/eigenwise) or [a GitHub sponsorship](https://github.com/sponsors/Eigenwise) genuinely helps me keep building and maintaining these tools.
 
+| Ko-fi | GitHub Sponsors |
+|:-----:|:---------------:|
+| <a href="https://ko-fi.com/eigenwise"><img height="32" alt="Support me on Ko-fi" src="https://ko-fi.com/img/githubbutton_sm.svg"></a> | <a href="https://github.com/sponsors/Eigenwise"><img height="32" alt="Sponsor on GitHub" src="https://img.shields.io/badge/Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white"></a> |
+
 ## License
 
 MIT (c) Eigenwise

--- a/plugins/sidequest/README.md
+++ b/plugins/sidequest/README.md
@@ -443,6 +443,10 @@ Two optional environment variables (set them in `.claude/settings.json` under `e
 
 sidequest is free and MIT-licensed. If it saves you time, [a coffee](https://ko-fi.com/eigenwise) or [a GitHub sponsorship](https://github.com/sponsors/Eigenwise) genuinely helps me keep building and maintaining these tools.
 
+| Ko-fi | GitHub Sponsors |
+|:-----:|:---------------:|
+| <a href="https://ko-fi.com/eigenwise"><img height="32" alt="Support me on Ko-fi" src="https://ko-fi.com/img/githubbutton_sm.svg"></a> | <a href="https://github.com/sponsors/Eigenwise"><img height="32" alt="Sponsor on GitHub" src="https://img.shields.io/badge/Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white"></a> |
+
 ## License
 
 MIT (c) Eigenwise

--- a/plugins/switchboard/README.md
+++ b/plugins/switchboard/README.md
@@ -158,6 +158,10 @@ tests, and each plugin's tests are the source of truth for changes to its copy.
 
 switchboard is free and MIT-licensed. If it saves you time, [a coffee](https://ko-fi.com/eigenwise) or [a GitHub sponsorship](https://github.com/sponsors/Eigenwise) genuinely helps me keep building and maintaining these tools.
 
+| Ko-fi | GitHub Sponsors |
+|:-----:|:---------------:|
+| <a href="https://ko-fi.com/eigenwise"><img height="32" alt="Support me on Ko-fi" src="https://ko-fi.com/img/githubbutton_sm.svg"></a> | <a href="https://github.com/sponsors/Eigenwise"><img height="32" alt="Sponsor on GitHub" src="https://img.shields.io/badge/Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white"></a> |
+
 ## License
 
 MIT (c) Eigenwise

--- a/plugins/workspace-init/README.md
+++ b/plugins/workspace-init/README.md
@@ -96,6 +96,10 @@ harness saw the name "already loaded" and skipped the body). So this plugin ship
 
 workspace-init is free and MIT-licensed. If it saves you time, [a coffee](https://ko-fi.com/eigenwise) or [a GitHub sponsorship](https://github.com/sponsors/Eigenwise) genuinely helps me keep building and maintaining these tools.
 
+| Ko-fi | GitHub Sponsors |
+|:-----:|:---------------:|
+| <a href="https://ko-fi.com/eigenwise"><img height="32" alt="Support me on Ko-fi" src="https://ko-fi.com/img/githubbutton_sm.svg"></a> | <a href="https://github.com/sponsors/Eigenwise"><img height="32" alt="Sponsor on GitHub" src="https://img.shields.io/badge/Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white"></a> |
+
 ## License
 
 [MIT](../../LICENSE) © Kenny Vaneetvelde


### PR DESCRIPTION
Adds the root README's Ko-fi/GitHub-Sponsors button table to every plugin README's Support section (and under the haiku-jar footer), so the support options are visible at a glance instead of buried in a sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)