### PR TITLE
docs: support buttons at the top of every README too

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 [![Discord](https://img.shields.io/badge/chat-on_discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/J3W9b5AZJR)
 [![GitHub stars](https://img.shields.io/github/stars/Eigenwise/eigenwise-toolshed?style=social)](https://github.com/Eigenwise/eigenwise-toolshed/stargazers)
 
+<p align="center">
+  <a href="https://ko-fi.com/eigenwise"><img height="32" alt="Support me on Ko-fi" src="https://ko-fi.com/img/githubbutton_sm.svg"></a>
+  &nbsp;
+  <a href="https://github.com/sponsors/Eigenwise"><img height="32" alt="Sponsor on GitHub" src="https://img.shields.io/badge/Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white"></a>
+</p>
+
 A small, growing marketplace of [Claude Code](https://claude.com/claude-code) plugins.
 
 > Sharp little tools for Claude Code, kept in one shed. 🛠️

--- a/plugins/codebase-mapper/README.md
+++ b/plugins/codebase-mapper/README.md
@@ -7,6 +7,12 @@
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
 [![Discord](https://img.shields.io/badge/chat-on_discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/J3W9b5AZJR)
 
+<p align="center">
+  <a href="https://ko-fi.com/eigenwise"><img height="32" alt="Support me on Ko-fi" src="https://ko-fi.com/img/githubbutton_sm.svg"></a>
+  &nbsp;
+  <a href="https://github.com/sponsors/Eigenwise"><img height="32" alt="Sponsor on GitHub" src="https://img.shields.io/badge/Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white"></a>
+</p>
+
 A self-maintaining **codebase map** for Claude Code: small Markdown docs under
 `.claude/.codebase-info/` that describe how your project is built, re-injected into context on every
 prompt so Claude starts each session already knowing the layout instead of grepping around blind.

--- a/plugins/live-rules/README.md
+++ b/plugins/live-rules/README.md
@@ -7,6 +7,12 @@
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
 [![Discord](https://img.shields.io/badge/chat-on_discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/J3W9b5AZJR)
 
+<p align="center">
+  <a href="https://ko-fi.com/eigenwise"><img height="32" alt="Support me on Ko-fi" src="https://ko-fi.com/img/githubbutton_sm.svg"></a>
+  &nbsp;
+  <a href="https://github.com/sponsors/Eigenwise"><img height="32" alt="Sponsor on GitHub" src="https://img.shields.io/badge/Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white"></a>
+</p>
+
 **Developer-friendly, live rules for Claude Code.** Keep your rules in one Markdown file
 (`.claude/live-rules.md` by default, or anywhere you like), and a pair of bundled hooks re-inject the
 ones that apply, right when they apply: global rules and prompt-keyword rules on every prompt,

--- a/plugins/sidequest/README.md
+++ b/plugins/sidequest/README.md
@@ -7,6 +7,12 @@
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
 [![Discord](https://img.shields.io/badge/chat-on_discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/J3W9b5AZJR)
 
+<p align="center">
+  <a href="https://ko-fi.com/eigenwise"><img height="32" alt="Support me on Ko-fi" src="https://ko-fi.com/img/githubbutton_sm.svg"></a>
+  &nbsp;
+  <a href="https://github.com/sponsors/Eigenwise"><img height="32" alt="Sponsor on GitHub" src="https://img.shields.io/badge/Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white"></a>
+</p>
+
 **A Trello-light quest log for Claude Code.** The stray issues you mention while Claude is busy with
 something else — *"oh, and the contact form doesn't send"* — get captured as **tickets** on the spot,
 with any image you pasted attached, and land on a **live, self-hosted Kanban dashboard** that spans

--- a/plugins/switchboard/README.md
+++ b/plugins/switchboard/README.md
@@ -7,6 +7,12 @@
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
 [![Discord](https://img.shields.io/badge/chat-on_discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/J3W9b5AZJR)
 
+<p align="center">
+  <a href="https://ko-fi.com/eigenwise"><img height="32" alt="Support me on Ko-fi" src="https://ko-fi.com/img/githubbutton_sm.svg"></a>
+  &nbsp;
+  <a href="https://github.com/sponsors/Eigenwise"><img height="32" alt="Sponsor on GitHub" src="https://img.shields.io/badge/Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white"></a>
+</p>
+
 **Score the task, not the model.** Claude scores each piece of work for complexity (1 to 10),
 switchboard turns that score into a model tier and a reasoning effort, and the work runs in a
 named executor subagent at exactly that tier. Nobody hand-picks models anymore: the score is the

--- a/plugins/workspace-init/README.md
+++ b/plugins/workspace-init/README.md
@@ -7,6 +7,12 @@
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/eigenwise)
 [![Discord](https://img.shields.io/badge/chat-on_discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/J3W9b5AZJR)
 
+<p align="center">
+  <a href="https://ko-fi.com/eigenwise"><img height="32" alt="Support me on Ko-fi" src="https://ko-fi.com/img/githubbutton_sm.svg"></a>
+  &nbsp;
+  <a href="https://github.com/sponsors/Eigenwise"><img height="32" alt="Sponsor on GitHub" src="https://img.shields.io/badge/Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white"></a>
+</p>
+
 One command to set up a Claude Code workspace for a project, new or existing. It runs a short
 interview, then writes a populated `.claude/`: a `settings.json` that enables the right plugins for
 your stack, a tailored `live-rules.md`, a codebase map, and a short note on how the project is meant to


### PR DESCRIPTION
Puts the centered Ko-fi + GitHub Sponsors buttons directly under the badge row on the root and all five plugin READMEs. The bottom Support sections stay as they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)