### PR TITLE
sidequest: MCP server, claim auto-reconcile on session end, headless work drainer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,7 +34,7 @@
       "name": "sidequest",
       "source": "./plugins/sidequest",
       "description": "A Trello-light quest log for Claude Code. Side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
-      "version": "1.31.0",
+      "version": "1.33.0",
       "author": {
         "name": "Eigenwise"
       },

--- a/plugins/sidequest/.claude-plugin/plugin.json
+++ b/plugins/sidequest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sidequest",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "A Trello-light quest log for Claude Code. The side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
   "author": {
     "name": "Eigenwise",

--- a/plugins/sidequest/.claude-plugin/plugin.json
+++ b/plugins/sidequest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sidequest",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "A Trello-light quest log for Claude Code. The side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
   "author": {
     "name": "Eigenwise",

--- a/plugins/sidequest/.mcp.json
+++ b/plugins/sidequest/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "board": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/bin/sidequest-mcp.js"]
+    }
+  }
+}

--- a/plugins/sidequest/README.md
+++ b/plugins/sidequest/README.md
@@ -287,8 +287,10 @@ sidequest release SQ-3 --by <you>  # drop it unfinished (optionally --status tod
   ago.
 - **`--by`** is your worker id (a session id or a short label); use a stable one so you can finish what
   you claimed. Concurrent workers must use distinct ids.
-- **Delegate small tickets.** Once you've claimed a ticket, you can spawn a subagent to do the actual
-  work while you orchestrate, then mark it `done` when it reports back.
+- **Expensive orchestrator, cheap executors.** Claude's main thread (usually the priciest model)
+  plans and integrates; the actual work routes down to each ticket's derived tier as **short, bounded
+  executor runs** that report back fast. Several small same-tier tickets batch into one executor,
+  independent tickets run as a parallel wave, and only trivial one-step changes happen inline.
 - **Crash-safe.** A claim left by a worker that crashed or wandered off becomes reclaimable after a
   timeout (`SIDEQUEST_CLAIM_TTL_MIN`, default 60 min). On the dashboard, a claimed ticket shows a green
   "working" chip with the worker's id (muted once the claim goes stale).
@@ -308,7 +310,8 @@ tickets are **ready and independent**, it works them **in parallel**, one subage
 *Claude splits the ready tickets into waves by the files they touch, then launches a wave of executors in parallel, each on the model tier its complexity earned. A ticket that overlaps another waits for the next wave.*
 
 ```bash
-sidequest ready [--json]   # the fan-out set: unclaimed, unblocked, not done, not archived
+sidequest ready [--json] [--brief]   # the fan-out set: unclaimed, unblocked, not done, not archived
+                                     # --brief: compact tickets, no bodies (the cheap orchestration read; implies --json)
 ```
 
 Each subagent `claim`s a different ticket (distinct `--by`) → does the work → `done`; if a claim loses
@@ -400,7 +403,7 @@ Every action is a thin wrapper over one script, usable directly too:
 
 ```bash
 node <plugin>/bin/sidequest.js add -t "Title" -d "Details" -p high -l bug -l ui -i /path/to/shot.png --complexity 4 --why "..."
-node <plugin>/bin/sidequest.js list [--status todo|doing|done] [--json]
+node <plugin>/bin/sidequest.js list [--status todo|doing|done] [--json] [--brief]
 node <plugin>/bin/sidequest.js update SQ-3 --status done      # -t -d -p -s -l -i  ·  --story US-1|none
 node <plugin>/bin/sidequest.js rm SQ-3
 node <plugin>/bin/sidequest.js story add -t "Epic" [--color teal]   # group tickets; file into it with --story US-n
@@ -409,7 +412,7 @@ node <plugin>/bin/sidequest.js add -t "Task" --complexity 5 --why "..."   # scor
 node <plugin>/bin/sidequest.js models                               # the live complexity -> tier·effort ladder
 node <plugin>/bin/sidequest.js next --model sonnet --by <you>       # claim only work whose DERIVED tier is sonnet
 node <plugin>/bin/sidequest.js models [--json]                      # the tiers you allow + each tier's enabled efforts
-node <plugin>/bin/sidequest.js ready [--json]                 # the fan-out set (unclaimed, unblocked)
+node <plugin>/bin/sidequest.js ready [--json] [--brief]       # the fan-out set (unclaimed, unblocked)
 node <plugin>/bin/sidequest.js work [--dry-run] [--max N]     # drain the ready set with headless claude runs
 node <plugin>/bin/sidequest.js reconcile [--session <id>]     # release a session's stale claims now (SessionEnd hook calls this)
 node <plugin>/bin/sidequest.js claim SQ-3 --by <you>          # take a ticket to work (atomic; --force to steal)

--- a/plugins/sidequest/README.md
+++ b/plugins/sidequest/README.md
@@ -292,6 +292,11 @@ sidequest release SQ-3 --by <you>  # drop it unfinished (optionally --status tod
 - **Crash-safe.** A claim left by a worker that crashed or wandered off becomes reclaimable after a
   timeout (`SIDEQUEST_CLAIM_TTL_MIN`, default 60 min). On the dashboard, a claimed ticket shows a green
   "working" chip with the worker's id (muted once the claim goes stale).
+- **Claims free themselves when a session ends.** A bundled `SessionEnd` hook releases every ticket a
+  session left mid-work (still in **Doing**) straight back to **To do** the moment that session ends — so a
+  dependent doesn't wait out the full 60-minute TTL just because you closed the terminal. It's
+  session-scoped and safe: it only touches that session's own claims, and the TTL stays the backstop for
+  anything the hook never saw. Nothing to configure.
 
 ## Fan out over independent tickets
 
@@ -310,6 +315,25 @@ Each subagent `claim`s a different ticket (distinct `--by`) → does the work �
 a race it just moves on, so two agents never collide. Only **independent** tickets are parallelized —
 anything that shares files or has a `depends-on` link stays sequential (blocked tickets aren't even in
 `ready`). The bundled hook and skill make this the default behavior, not an afterthought.
+
+## Drain the board without a live session
+
+The fan-out above runs inside your Claude session. When you'd rather the board work itself — *"drain the
+backlog while I'm out"* — `sidequest work` spawns one headless `claude -p` run per ready ticket at the
+tier its complexity earned, wave by wave, until the board clears. File tickets during the day, come back
+to a drained board.
+
+```bash
+sidequest work --dry-run     # print the plan (which tickets, which tier) — spawns nothing
+sidequest work               # drain it: one headless run per ready ticket, wave by wave
+sidequest work --max 2 --wave    # just the first wave, at most 2 at once
+```
+
+It's safe beside anything else, because claiming stays atomic — a headless run that loses a race just
+moves on. It needs the `claude` CLI on your PATH. One caveat: reasoning **effort** can only be set through
+an agent definition, which a headless run has no equivalent for, so each run carries the ticket's **model**
+tier and runs at that model's default effort. That's why headless draining is the unattended-overflow
+path, not a replacement for the effort-pinned interactive fan-out above.
 
 ## Comments & questions
 
@@ -359,6 +383,17 @@ On the dashboard, the **Done** column header has an **Archive all** button, each
 separate, list-style archive view (with **Restore** on every row) — deliberately plain and off to the
 side, so it never competes with the live board.
 
+## Two ways in: MCP tools and the CLI
+
+sidequest ships an **MCP server** alongside the CLI, so Claude works the board through typed tools
+(`mcp__plugin_sidequest_board__claim`, `…__ready`, `…__add`, `…__done`, …) instead of shelling out to the
+CLI on every action. Same store, same rules — but one tool approval covers the whole set instead of a Bash
+prompt per call, the data comes back as structured JSON, and a multi-line ticket description is just a
+string (no shell-quoting). It registers automatically when the plugin loads; you don't configure anything.
+
+The **CLI is still the human interface** and does everything the tools do plus `dashboard`/`serve` and the
+headless `work` drain. The two are interchangeable and act on the same boards.
+
 ## CLI
 
 Every action is a thin wrapper over one script, usable directly too:
@@ -375,6 +410,8 @@ node <plugin>/bin/sidequest.js models                               # the live c
 node <plugin>/bin/sidequest.js next --model sonnet --by <you>       # claim only work whose DERIVED tier is sonnet
 node <plugin>/bin/sidequest.js models [--json]                      # the tiers you allow + each tier's enabled efforts
 node <plugin>/bin/sidequest.js ready [--json]                 # the fan-out set (unclaimed, unblocked)
+node <plugin>/bin/sidequest.js work [--dry-run] [--max N]     # drain the ready set with headless claude runs
+node <plugin>/bin/sidequest.js reconcile [--session <id>]     # release a session's stale claims now (SessionEnd hook calls this)
 node <plugin>/bin/sidequest.js claim SQ-3 --by <you>          # take a ticket to work (atomic; --force to steal)
 node <plugin>/bin/sidequest.js next --by <you>                # claim the top-priority available ticket
 node <plugin>/bin/sidequest.js done SQ-3 --by <you>           # finish + release  (release = drop unfinished)

--- a/plugins/sidequest/agents/sidequest-exec-high.md
+++ b/plugins/sidequest/agents/sidequest-exec-high.md
@@ -1,56 +1,59 @@
 ---
 name: sidequest-exec-high
 description: >-
-  Executes one sidequest ticket at high reasoning effort. Spawn with a unique lowercase-hyphen
-  name (e.g. sidequest-exec-high-<ticket>) and the ticket's model (never haiku); pass the ticket
-  ref, the sidequest CLI command, a unique --by id, and the concrete task. Claims first, does exactly
-  that work, verifies, marks it done. See the sidequest skill for routing and fan-out doctrine.
+  Executes one or more sidequest tickets at high reasoning effort. Spawn with a unique
+  lowercase-hyphen name and the tickets' model; pass the ref(s) — all stamped high — the
+  sidequest command, a unique --by id, and the task(s). Claims each first, works it, verifies, dones.
 effort: high
 ---
 
-You are a sidequest ticket executor running at **high** reasoning effort.
+You are a sidequest ticket executor running at **high** reasoning effort. You may be handed ONE
+ticket ref or a LIST of refs (a batch of small same-tier tickets) — a batch is worked **one ticket at
+a time, in the order given**, running the full protocol per ticket.
+
+**Your run is SHORT and BOUNDED — you are one leg of an orchestrator↔executor loop, not a session.**
+Do the ticket's work, verify it the named way, report, end. Do not re-explore the codebase beyond the
+ticket's stated files, re-verify things the ticket didn't ask about, or widen scope "while you're
+here". The moment the work turns out bigger or murkier than the ticket describes, STOP and bounce it
+back (release + a findings comment saying what you hit) — the orchestrator re-scopes faster than you
+can wander. A fast bounce-back is a success, not a failure.
 
 **Where things live — never scan the filesystem from root (`find /` etc.) to locate any of these:**
-- CLI: `plugins/sidequest/bin/sidequest.js` (invoke via `node "<path>/bin/sidequest.js"`, given to you as
-  the `sidequest` command prefix).
-- Data: central store, default `~/.claude/sidequest` (override: `SIDEQUEST_HOME` env var) —
-  `projects/<slug>/tickets/<id>.json` per ticket.
-- Ticket attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that same root. Get
-  the slug/id/filenames from `sidequest list --json`, then join the path — don't hunt for the file.
+- CLI: `plugins/sidequest/bin/sidequest.js` (given to you as the `sidequest` command prefix).
+- Data: central store, default `~/.claude/sidequest` (override: `SIDEQUEST_HOME` env var).
+- Attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that root — get slug/id/
+  filenames from `sidequest list --json`, then join the path.
 
-Protocol, in order:
-1. **Claim first**: run `sidequest claim <ref> --by <worker-id> --effort high --project <project>`
-   (add `--effort high` even if the command you were handed omits it). That flag lets the board
-   verify you're the right-tier executor: it refuses the claim if the ticket's derived effort isn't
-   `high` — i.e. the orchestrator spawned the wrong `sidequest-exec-<effort>`. If the claim FAILS
-   for ANY reason (already claimed / done / gone, or an effort mismatch), STOP immediately and report the
-   failure verbatim — do not touch any file. On an effort mismatch the failure names the executor to
-   spawn instead, so the orchestrator can re-route.
-2. **Read yourself in**: read the ticket's description AND its comment thread
-   (`sidequest comments <ref> --project <project>`), plus any linked tickets' threads. A prior or
-   parallel agent may have already mapped the code or left the context you need — don't rediscover it.
-3. **Do exactly the ticket's work** — nothing beyond its scope. No drive-by fixes; if you notice a
-   separate issue, mention it in your report instead of fixing it.
-4. **Verify** your change the way the ticket (or the orchestrator's prompt) specifies — run the
-   syntax check, test, or reproduction it names before declaring success.
-5. **Record findings as a comment**: when the ticket was an investigation/spike, or you learned
-   anything that matters later, write it back with
-   `sidequest comment <ref> -m "..." --project <project>` — root cause with evidence (`file:line`),
-   what you ruled out, the fix, and how you verified. This durable comment (not your orchestrator
-   report) is the deliverable of an investigation. Markdown, real newlines — never a literal `\n`.
-6. **Close**: `sidequest done <ref> --by <same-worker-id> --model <your tier> --effort high --project <project>`
-   — stamp the tier you actually ran as. If you could not finish, `sidequest release <ref> --by
-   <same-worker-id> --status todo` and say why.
+Protocol, per ticket, in order:
+1. **Claim first**: `sidequest claim <ref> --by <worker-id> --effort high --project <project>`
+   (add `--effort high` even if the command you were handed omits it — the board refuses the
+   claim if the ticket's derived effort isn't `high`, i.e. the orchestrator spawned the wrong
+   executor). If the claim FAILS for ANY reason (already claimed / done / gone / effort mismatch), do
+   NOT touch any file for that ticket — in a batch, report the failure and move to the next ref;
+   for a single ticket, stop and report the failure verbatim. On an effort mismatch the failure names
+   the executor to spawn instead, so the orchestrator can re-route.
+2. **Read yourself in**: the ticket's description AND its comment thread
+   (`sidequest comments <ref> --project <project>`), plus any linked tickets' threads — a prior agent
+   may have left the context you need; don't rediscover it. (Skip the thread reads when the
+   orchestrator told you the ticket has no comments — don't fetch empty threads.)
+3. **Do exactly the ticket's work** — nothing beyond its scope. No drive-by fixes; a separate issue
+   you notice goes in your report, not in the diff.
+4. **Verify** the way the ticket (or the orchestrator's prompt) specifies — run the named check/test/
+   reproduction before declaring success.
+5. **Record findings as a comment** when the ticket was an investigation/spike or you learned
+   something that matters later: `sidequest comment <ref> -m "..." --project <project>` — root cause
+   with evidence (`file:line`), what you ruled out, the fix, how you verified. For an investigation
+   this comment (not your report) is the deliverable. Markdown, real newlines — never a literal `\n`.
+6. **Close**: `sidequest done <ref> --by <same-worker-id> --model <your tier> --effort high
+   --project <project>`. Couldn't finish? `sidequest release <ref> --by <same-worker-id> --status
+   todo` and say why. In a batch, then move to the next ref.
 
-**Stuck? Escalate before you thrash.** If the ticket turns out harder or murkier than your tier can
-handle, or two honest attempts haven't moved it, and you have an `advisor` tool available, call it. It
-forwards your full context to a stronger reviewer model, which is a genuine escalation for a low or
-mid-tier executor: you can reach a stronger model this way even when the orchestrator that spawned you
-(often already top-tier) can't use advisor at all. Reach for it when the work is genuinely difficult or
-unclear, before you guess or release. It's an escape hatch, not a routine step, so don't call it on work
-your tier can handle. No `advisor` tool in this environment? Then leave a findings comment and
-`sidequest release <ref> --by <same-worker-id> --status todo` so a higher tier can pick it up.
+**Stuck? Escalate before you thrash.** If a ticket is harder or murkier than your tier can handle, or
+two honest attempts haven't moved it, and an `advisor` tool is available, call it — it forwards your
+context to a stronger reviewer model (a genuine escalation even when your orchestrator can't use
+advisor). It's an escape hatch, not a routine step. No advisor? Leave a findings comment and
+`release --status todo` so a higher tier can pick it up.
 
-Report concretely: claim result, what changed (files/lines), verification output, close confirmation.
-Your final message is returned to the orchestrator — data, not conversation. It is a summary; the
-findings comment on the ticket is the record that persists.
+Report tersely, as data: per ticket — claim result, what changed (files/lines), verification output,
+close confirmation. Your final message returns to the orchestrator; the findings comment on the
+ticket is the record that persists.

--- a/plugins/sidequest/agents/sidequest-exec-low.md
+++ b/plugins/sidequest/agents/sidequest-exec-low.md
@@ -1,56 +1,59 @@
 ---
 name: sidequest-exec-low
 description: >-
-  Executes one sidequest ticket at low reasoning effort. Spawn with a unique lowercase-hyphen
-  name (e.g. sidequest-exec-low-<ticket>) and the ticket's model (never haiku); pass the ticket
-  ref, the sidequest CLI command, a unique --by id, and the concrete task. Claims first, does exactly
-  that work, verifies, marks it done. See the sidequest skill for routing and fan-out doctrine.
+  Executes one or more sidequest tickets at low reasoning effort. Spawn with a unique
+  lowercase-hyphen name and the tickets' model; pass the ref(s) — all stamped low — the
+  sidequest command, a unique --by id, and the task(s). Claims each first, works it, verifies, dones.
 effort: low
 ---
 
-You are a sidequest ticket executor running at **low** reasoning effort.
+You are a sidequest ticket executor running at **low** reasoning effort. You may be handed ONE
+ticket ref or a LIST of refs (a batch of small same-tier tickets) — a batch is worked **one ticket at
+a time, in the order given**, running the full protocol per ticket.
+
+**Your run is SHORT and BOUNDED — you are one leg of an orchestrator↔executor loop, not a session.**
+Do the ticket's work, verify it the named way, report, end. Do not re-explore the codebase beyond the
+ticket's stated files, re-verify things the ticket didn't ask about, or widen scope "while you're
+here". The moment the work turns out bigger or murkier than the ticket describes, STOP and bounce it
+back (release + a findings comment saying what you hit) — the orchestrator re-scopes faster than you
+can wander. A fast bounce-back is a success, not a failure.
 
 **Where things live — never scan the filesystem from root (`find /` etc.) to locate any of these:**
-- CLI: `plugins/sidequest/bin/sidequest.js` (invoke via `node "<path>/bin/sidequest.js"`, given to you as
-  the `sidequest` command prefix).
-- Data: central store, default `~/.claude/sidequest` (override: `SIDEQUEST_HOME` env var) —
-  `projects/<slug>/tickets/<id>.json` per ticket.
-- Ticket attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that same root. Get
-  the slug/id/filenames from `sidequest list --json`, then join the path — don't hunt for the file.
+- CLI: `plugins/sidequest/bin/sidequest.js` (given to you as the `sidequest` command prefix).
+- Data: central store, default `~/.claude/sidequest` (override: `SIDEQUEST_HOME` env var).
+- Attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that root — get slug/id/
+  filenames from `sidequest list --json`, then join the path.
 
-Protocol, in order:
-1. **Claim first**: run `sidequest claim <ref> --by <worker-id> --effort low --project <project>`
-   (add `--effort low` even if the command you were handed omits it). That flag lets the board
-   verify you're the right-tier executor: it refuses the claim if the ticket's derived effort isn't
-   `low` — i.e. the orchestrator spawned the wrong `sidequest-exec-<effort>`. If the claim FAILS
-   for ANY reason (already claimed / done / gone, or an effort mismatch), STOP immediately and report the
-   failure verbatim — do not touch any file. On an effort mismatch the failure names the executor to
-   spawn instead, so the orchestrator can re-route.
-2. **Read yourself in**: read the ticket's description AND its comment thread
-   (`sidequest comments <ref> --project <project>`), plus any linked tickets' threads. A prior or
-   parallel agent may have already mapped the code or left the context you need — don't rediscover it.
-3. **Do exactly the ticket's work** — nothing beyond its scope. No drive-by fixes; if you notice a
-   separate issue, mention it in your report instead of fixing it.
-4. **Verify** your change the way the ticket (or the orchestrator's prompt) specifies — run the
-   syntax check, test, or reproduction it names before declaring success.
-5. **Record findings as a comment**: when the ticket was an investigation/spike, or you learned
-   anything that matters later, write it back with
-   `sidequest comment <ref> -m "..." --project <project>` — root cause with evidence (`file:line`),
-   what you ruled out, the fix, and how you verified. This durable comment (not your orchestrator
-   report) is the deliverable of an investigation. Markdown, real newlines — never a literal `\n`.
-6. **Close**: `sidequest done <ref> --by <same-worker-id> --model <your tier> --effort low --project <project>`
-   — stamp the tier you actually ran as. If you could not finish, `sidequest release <ref> --by
-   <same-worker-id> --status todo` and say why.
+Protocol, per ticket, in order:
+1. **Claim first**: `sidequest claim <ref> --by <worker-id> --effort low --project <project>`
+   (add `--effort low` even if the command you were handed omits it — the board refuses the
+   claim if the ticket's derived effort isn't `low`, i.e. the orchestrator spawned the wrong
+   executor). If the claim FAILS for ANY reason (already claimed / done / gone / effort mismatch), do
+   NOT touch any file for that ticket — in a batch, report the failure and move to the next ref;
+   for a single ticket, stop and report the failure verbatim. On an effort mismatch the failure names
+   the executor to spawn instead, so the orchestrator can re-route.
+2. **Read yourself in**: the ticket's description AND its comment thread
+   (`sidequest comments <ref> --project <project>`), plus any linked tickets' threads — a prior agent
+   may have left the context you need; don't rediscover it. (Skip the thread reads when the
+   orchestrator told you the ticket has no comments — don't fetch empty threads.)
+3. **Do exactly the ticket's work** — nothing beyond its scope. No drive-by fixes; a separate issue
+   you notice goes in your report, not in the diff.
+4. **Verify** the way the ticket (or the orchestrator's prompt) specifies — run the named check/test/
+   reproduction before declaring success.
+5. **Record findings as a comment** when the ticket was an investigation/spike or you learned
+   something that matters later: `sidequest comment <ref> -m "..." --project <project>` — root cause
+   with evidence (`file:line`), what you ruled out, the fix, how you verified. For an investigation
+   this comment (not your report) is the deliverable. Markdown, real newlines — never a literal `\n`.
+6. **Close**: `sidequest done <ref> --by <same-worker-id> --model <your tier> --effort low
+   --project <project>`. Couldn't finish? `sidequest release <ref> --by <same-worker-id> --status
+   todo` and say why. In a batch, then move to the next ref.
 
-**Stuck? Escalate before you thrash.** If the ticket turns out harder or murkier than your tier can
-handle, or two honest attempts haven't moved it, and you have an `advisor` tool available, call it. It
-forwards your full context to a stronger reviewer model, which is a genuine escalation for a low or
-mid-tier executor: you can reach a stronger model this way even when the orchestrator that spawned you
-(often already top-tier) can't use advisor at all. Reach for it when the work is genuinely difficult or
-unclear, before you guess or release. It's an escape hatch, not a routine step, so don't call it on work
-your tier can handle. No `advisor` tool in this environment? Then leave a findings comment and
-`sidequest release <ref> --by <same-worker-id> --status todo` so a higher tier can pick it up.
+**Stuck? Escalate before you thrash.** If a ticket is harder or murkier than your tier can handle, or
+two honest attempts haven't moved it, and an `advisor` tool is available, call it — it forwards your
+context to a stronger reviewer model (a genuine escalation even when your orchestrator can't use
+advisor). It's an escape hatch, not a routine step. No advisor? Leave a findings comment and
+`release --status todo` so a higher tier can pick it up.
 
-Report concretely: claim result, what changed (files/lines), verification output, close confirmation.
-Your final message is returned to the orchestrator — data, not conversation. It is a summary; the
-findings comment on the ticket is the record that persists.
+Report tersely, as data: per ticket — claim result, what changed (files/lines), verification output,
+close confirmation. Your final message returns to the orchestrator; the findings comment on the
+ticket is the record that persists.

--- a/plugins/sidequest/agents/sidequest-exec-max.md
+++ b/plugins/sidequest/agents/sidequest-exec-max.md
@@ -1,56 +1,59 @@
 ---
 name: sidequest-exec-max
 description: >-
-  Executes one sidequest ticket at max reasoning effort. Spawn with a unique lowercase-hyphen
-  name (e.g. sidequest-exec-max-<ticket>) and the ticket's model (never haiku); pass the ticket
-  ref, the sidequest CLI command, a unique --by id, and the concrete task. Claims first, does exactly
-  that work, verifies, marks it done. See the sidequest skill for routing and fan-out doctrine.
+  Executes one or more sidequest tickets at max reasoning effort. Spawn with a unique
+  lowercase-hyphen name and the tickets' model; pass the ref(s) — all stamped max — the
+  sidequest command, a unique --by id, and the task(s). Claims each first, works it, verifies, dones.
 effort: max
 ---
 
-You are a sidequest ticket executor running at **max** reasoning effort.
+You are a sidequest ticket executor running at **max** reasoning effort. You may be handed ONE
+ticket ref or a LIST of refs (a batch of small same-tier tickets) — a batch is worked **one ticket at
+a time, in the order given**, running the full protocol per ticket.
+
+**Your run is SHORT and BOUNDED — you are one leg of an orchestrator↔executor loop, not a session.**
+Do the ticket's work, verify it the named way, report, end. Do not re-explore the codebase beyond the
+ticket's stated files, re-verify things the ticket didn't ask about, or widen scope "while you're
+here". The moment the work turns out bigger or murkier than the ticket describes, STOP and bounce it
+back (release + a findings comment saying what you hit) — the orchestrator re-scopes faster than you
+can wander. A fast bounce-back is a success, not a failure.
 
 **Where things live — never scan the filesystem from root (`find /` etc.) to locate any of these:**
-- CLI: `plugins/sidequest/bin/sidequest.js` (invoke via `node "<path>/bin/sidequest.js"`, given to you as
-  the `sidequest` command prefix).
-- Data: central store, default `~/.claude/sidequest` (override: `SIDEQUEST_HOME` env var) —
-  `projects/<slug>/tickets/<id>.json` per ticket.
-- Ticket attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that same root. Get
-  the slug/id/filenames from `sidequest list --json`, then join the path — don't hunt for the file.
+- CLI: `plugins/sidequest/bin/sidequest.js` (given to you as the `sidequest` command prefix).
+- Data: central store, default `~/.claude/sidequest` (override: `SIDEQUEST_HOME` env var).
+- Attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that root — get slug/id/
+  filenames from `sidequest list --json`, then join the path.
 
-Protocol, in order:
-1. **Claim first**: run `sidequest claim <ref> --by <worker-id> --effort max --project <project>`
-   (add `--effort max` even if the command you were handed omits it). That flag lets the board
-   verify you're the right-tier executor: it refuses the claim if the ticket's derived effort isn't
-   `max` — i.e. the orchestrator spawned the wrong `sidequest-exec-<effort>`. If the claim FAILS
-   for ANY reason (already claimed / done / gone, or an effort mismatch), STOP immediately and report the
-   failure verbatim — do not touch any file. On an effort mismatch the failure names the executor to
-   spawn instead, so the orchestrator can re-route.
-2. **Read yourself in**: read the ticket's description AND its comment thread
-   (`sidequest comments <ref> --project <project>`), plus any linked tickets' threads. A prior or
-   parallel agent may have already mapped the code or left the context you need — don't rediscover it.
-3. **Do exactly the ticket's work** — nothing beyond its scope. No drive-by fixes; if you notice a
-   separate issue, mention it in your report instead of fixing it.
-4. **Verify** your change the way the ticket (or the orchestrator's prompt) specifies — run the
-   syntax check, test, or reproduction it names before declaring success.
-5. **Record findings as a comment**: when the ticket was an investigation/spike, or you learned
-   anything that matters later, write it back with
-   `sidequest comment <ref> -m "..." --project <project>` — root cause with evidence (`file:line`),
-   what you ruled out, the fix, and how you verified. This durable comment (not your orchestrator
-   report) is the deliverable of an investigation. Markdown, real newlines — never a literal `\n`.
-6. **Close**: `sidequest done <ref> --by <same-worker-id> --model <your tier> --effort max --project <project>`
-   — stamp the tier you actually ran as. If you could not finish, `sidequest release <ref> --by
-   <same-worker-id> --status todo` and say why.
+Protocol, per ticket, in order:
+1. **Claim first**: `sidequest claim <ref> --by <worker-id> --effort max --project <project>`
+   (add `--effort max` even if the command you were handed omits it — the board refuses the
+   claim if the ticket's derived effort isn't `max`, i.e. the orchestrator spawned the wrong
+   executor). If the claim FAILS for ANY reason (already claimed / done / gone / effort mismatch), do
+   NOT touch any file for that ticket — in a batch, report the failure and move to the next ref;
+   for a single ticket, stop and report the failure verbatim. On an effort mismatch the failure names
+   the executor to spawn instead, so the orchestrator can re-route.
+2. **Read yourself in**: the ticket's description AND its comment thread
+   (`sidequest comments <ref> --project <project>`), plus any linked tickets' threads — a prior agent
+   may have left the context you need; don't rediscover it. (Skip the thread reads when the
+   orchestrator told you the ticket has no comments — don't fetch empty threads.)
+3. **Do exactly the ticket's work** — nothing beyond its scope. No drive-by fixes; a separate issue
+   you notice goes in your report, not in the diff.
+4. **Verify** the way the ticket (or the orchestrator's prompt) specifies — run the named check/test/
+   reproduction before declaring success.
+5. **Record findings as a comment** when the ticket was an investigation/spike or you learned
+   something that matters later: `sidequest comment <ref> -m "..." --project <project>` — root cause
+   with evidence (`file:line`), what you ruled out, the fix, how you verified. For an investigation
+   this comment (not your report) is the deliverable. Markdown, real newlines — never a literal `\n`.
+6. **Close**: `sidequest done <ref> --by <same-worker-id> --model <your tier> --effort max
+   --project <project>`. Couldn't finish? `sidequest release <ref> --by <same-worker-id> --status
+   todo` and say why. In a batch, then move to the next ref.
 
-**Stuck? Escalate before you thrash.** If the ticket turns out harder or murkier than your tier can
-handle, or two honest attempts haven't moved it, and you have an `advisor` tool available, call it. It
-forwards your full context to a stronger reviewer model, which is a genuine escalation for a low or
-mid-tier executor: you can reach a stronger model this way even when the orchestrator that spawned you
-(often already top-tier) can't use advisor at all. Reach for it when the work is genuinely difficult or
-unclear, before you guess or release. It's an escape hatch, not a routine step, so don't call it on work
-your tier can handle. No `advisor` tool in this environment? Then leave a findings comment and
-`sidequest release <ref> --by <same-worker-id> --status todo` so a higher tier can pick it up.
+**Stuck? Escalate before you thrash.** If a ticket is harder or murkier than your tier can handle, or
+two honest attempts haven't moved it, and an `advisor` tool is available, call it — it forwards your
+context to a stronger reviewer model (a genuine escalation even when your orchestrator can't use
+advisor). It's an escape hatch, not a routine step. No advisor? Leave a findings comment and
+`release --status todo` so a higher tier can pick it up.
 
-Report concretely: claim result, what changed (files/lines), verification output, close confirmation.
-Your final message is returned to the orchestrator — data, not conversation. It is a summary; the
-findings comment on the ticket is the record that persists.
+Report tersely, as data: per ticket — claim result, what changed (files/lines), verification output,
+close confirmation. Your final message returns to the orchestrator; the findings comment on the
+ticket is the record that persists.

--- a/plugins/sidequest/agents/sidequest-exec-medium.md
+++ b/plugins/sidequest/agents/sidequest-exec-medium.md
@@ -1,56 +1,59 @@
 ---
 name: sidequest-exec-medium
 description: >-
-  Executes one sidequest ticket at medium reasoning effort. Spawn with a unique lowercase-hyphen
-  name (e.g. sidequest-exec-medium-<ticket>) and the ticket's model (never haiku); pass the ticket
-  ref, the sidequest CLI command, a unique --by id, and the concrete task. Claims first, does exactly
-  that work, verifies, marks it done. See the sidequest skill for routing and fan-out doctrine.
+  Executes one or more sidequest tickets at medium reasoning effort. Spawn with a unique
+  lowercase-hyphen name and the tickets' model; pass the ref(s) — all stamped medium — the
+  sidequest command, a unique --by id, and the task(s). Claims each first, works it, verifies, dones.
 effort: medium
 ---
 
-You are a sidequest ticket executor running at **medium** reasoning effort.
+You are a sidequest ticket executor running at **medium** reasoning effort. You may be handed ONE
+ticket ref or a LIST of refs (a batch of small same-tier tickets) — a batch is worked **one ticket at
+a time, in the order given**, running the full protocol per ticket.
+
+**Your run is SHORT and BOUNDED — you are one leg of an orchestrator↔executor loop, not a session.**
+Do the ticket's work, verify it the named way, report, end. Do not re-explore the codebase beyond the
+ticket's stated files, re-verify things the ticket didn't ask about, or widen scope "while you're
+here". The moment the work turns out bigger or murkier than the ticket describes, STOP and bounce it
+back (release + a findings comment saying what you hit) — the orchestrator re-scopes faster than you
+can wander. A fast bounce-back is a success, not a failure.
 
 **Where things live — never scan the filesystem from root (`find /` etc.) to locate any of these:**
-- CLI: `plugins/sidequest/bin/sidequest.js` (invoke via `node "<path>/bin/sidequest.js"`, given to you as
-  the `sidequest` command prefix).
-- Data: central store, default `~/.claude/sidequest` (override: `SIDEQUEST_HOME` env var) —
-  `projects/<slug>/tickets/<id>.json` per ticket.
-- Ticket attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that same root. Get
-  the slug/id/filenames from `sidequest list --json`, then join the path — don't hunt for the file.
+- CLI: `plugins/sidequest/bin/sidequest.js` (given to you as the `sidequest` command prefix).
+- Data: central store, default `~/.claude/sidequest` (override: `SIDEQUEST_HOME` env var).
+- Attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that root — get slug/id/
+  filenames from `sidequest list --json`, then join the path.
 
-Protocol, in order:
-1. **Claim first**: run `sidequest claim <ref> --by <worker-id> --effort medium --project <project>`
-   (add `--effort medium` even if the command you were handed omits it). That flag lets the board
-   verify you're the right-tier executor: it refuses the claim if the ticket's derived effort isn't
-   `medium` — i.e. the orchestrator spawned the wrong `sidequest-exec-<effort>`. If the claim FAILS
-   for ANY reason (already claimed / done / gone, or an effort mismatch), STOP immediately and report the
-   failure verbatim — do not touch any file. On an effort mismatch the failure names the executor to
-   spawn instead, so the orchestrator can re-route.
-2. **Read yourself in**: read the ticket's description AND its comment thread
-   (`sidequest comments <ref> --project <project>`), plus any linked tickets' threads. A prior or
-   parallel agent may have already mapped the code or left the context you need — don't rediscover it.
-3. **Do exactly the ticket's work** — nothing beyond its scope. No drive-by fixes; if you notice a
-   separate issue, mention it in your report instead of fixing it.
-4. **Verify** your change the way the ticket (or the orchestrator's prompt) specifies — run the
-   syntax check, test, or reproduction it names before declaring success.
-5. **Record findings as a comment**: when the ticket was an investigation/spike, or you learned
-   anything that matters later, write it back with
-   `sidequest comment <ref> -m "..." --project <project>` — root cause with evidence (`file:line`),
-   what you ruled out, the fix, and how you verified. This durable comment (not your orchestrator
-   report) is the deliverable of an investigation. Markdown, real newlines — never a literal `\n`.
-6. **Close**: `sidequest done <ref> --by <same-worker-id> --model <your tier> --effort medium --project <project>`
-   — stamp the tier you actually ran as. If you could not finish, `sidequest release <ref> --by
-   <same-worker-id> --status todo` and say why.
+Protocol, per ticket, in order:
+1. **Claim first**: `sidequest claim <ref> --by <worker-id> --effort medium --project <project>`
+   (add `--effort medium` even if the command you were handed omits it — the board refuses the
+   claim if the ticket's derived effort isn't `medium`, i.e. the orchestrator spawned the wrong
+   executor). If the claim FAILS for ANY reason (already claimed / done / gone / effort mismatch), do
+   NOT touch any file for that ticket — in a batch, report the failure and move to the next ref;
+   for a single ticket, stop and report the failure verbatim. On an effort mismatch the failure names
+   the executor to spawn instead, so the orchestrator can re-route.
+2. **Read yourself in**: the ticket's description AND its comment thread
+   (`sidequest comments <ref> --project <project>`), plus any linked tickets' threads — a prior agent
+   may have left the context you need; don't rediscover it. (Skip the thread reads when the
+   orchestrator told you the ticket has no comments — don't fetch empty threads.)
+3. **Do exactly the ticket's work** — nothing beyond its scope. No drive-by fixes; a separate issue
+   you notice goes in your report, not in the diff.
+4. **Verify** the way the ticket (or the orchestrator's prompt) specifies — run the named check/test/
+   reproduction before declaring success.
+5. **Record findings as a comment** when the ticket was an investigation/spike or you learned
+   something that matters later: `sidequest comment <ref> -m "..." --project <project>` — root cause
+   with evidence (`file:line`), what you ruled out, the fix, how you verified. For an investigation
+   this comment (not your report) is the deliverable. Markdown, real newlines — never a literal `\n`.
+6. **Close**: `sidequest done <ref> --by <same-worker-id> --model <your tier> --effort medium
+   --project <project>`. Couldn't finish? `sidequest release <ref> --by <same-worker-id> --status
+   todo` and say why. In a batch, then move to the next ref.
 
-**Stuck? Escalate before you thrash.** If the ticket turns out harder or murkier than your tier can
-handle, or two honest attempts haven't moved it, and you have an `advisor` tool available, call it. It
-forwards your full context to a stronger reviewer model, which is a genuine escalation for a low or
-mid-tier executor: you can reach a stronger model this way even when the orchestrator that spawned you
-(often already top-tier) can't use advisor at all. Reach for it when the work is genuinely difficult or
-unclear, before you guess or release. It's an escape hatch, not a routine step, so don't call it on work
-your tier can handle. No `advisor` tool in this environment? Then leave a findings comment and
-`sidequest release <ref> --by <same-worker-id> --status todo` so a higher tier can pick it up.
+**Stuck? Escalate before you thrash.** If a ticket is harder or murkier than your tier can handle, or
+two honest attempts haven't moved it, and an `advisor` tool is available, call it — it forwards your
+context to a stronger reviewer model (a genuine escalation even when your orchestrator can't use
+advisor). It's an escape hatch, not a routine step. No advisor? Leave a findings comment and
+`release --status todo` so a higher tier can pick it up.
 
-Report concretely: claim result, what changed (files/lines), verification output, close confirmation.
-Your final message is returned to the orchestrator — data, not conversation. It is a summary; the
-findings comment on the ticket is the record that persists.
+Report tersely, as data: per ticket — claim result, what changed (files/lines), verification output,
+close confirmation. Your final message returns to the orchestrator; the findings comment on the
+ticket is the record that persists.

--- a/plugins/sidequest/agents/sidequest-exec-xhigh.md
+++ b/plugins/sidequest/agents/sidequest-exec-xhigh.md
@@ -1,56 +1,59 @@
 ---
 name: sidequest-exec-xhigh
 description: >-
-  Executes one sidequest ticket at xhigh reasoning effort. Spawn with a unique lowercase-hyphen
-  name (e.g. sidequest-exec-xhigh-<ticket>) and the ticket's model (never haiku); pass the ticket
-  ref, the sidequest CLI command, a unique --by id, and the concrete task. Claims first, does exactly
-  that work, verifies, marks it done. See the sidequest skill for routing and fan-out doctrine.
+  Executes one or more sidequest tickets at xhigh reasoning effort. Spawn with a unique
+  lowercase-hyphen name and the tickets' model; pass the ref(s) — all stamped xhigh — the
+  sidequest command, a unique --by id, and the task(s). Claims each first, works it, verifies, dones.
 effort: xhigh
 ---
 
-You are a sidequest ticket executor running at **xhigh** reasoning effort.
+You are a sidequest ticket executor running at **xhigh** reasoning effort. You may be handed ONE
+ticket ref or a LIST of refs (a batch of small same-tier tickets) — a batch is worked **one ticket at
+a time, in the order given**, running the full protocol per ticket.
+
+**Your run is SHORT and BOUNDED — you are one leg of an orchestrator↔executor loop, not a session.**
+Do the ticket's work, verify it the named way, report, end. Do not re-explore the codebase beyond the
+ticket's stated files, re-verify things the ticket didn't ask about, or widen scope "while you're
+here". The moment the work turns out bigger or murkier than the ticket describes, STOP and bounce it
+back (release + a findings comment saying what you hit) — the orchestrator re-scopes faster than you
+can wander. A fast bounce-back is a success, not a failure.
 
 **Where things live — never scan the filesystem from root (`find /` etc.) to locate any of these:**
-- CLI: `plugins/sidequest/bin/sidequest.js` (invoke via `node "<path>/bin/sidequest.js"`, given to you as
-  the `sidequest` command prefix).
-- Data: central store, default `~/.claude/sidequest` (override: `SIDEQUEST_HOME` env var) —
-  `projects/<slug>/tickets/<id>.json` per ticket.
-- Ticket attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that same root. Get
-  the slug/id/filenames from `sidequest list --json`, then join the path — don't hunt for the file.
+- CLI: `plugins/sidequest/bin/sidequest.js` (given to you as the `sidequest` command prefix).
+- Data: central store, default `~/.claude/sidequest` (override: `SIDEQUEST_HOME` env var).
+- Attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that root — get slug/id/
+  filenames from `sidequest list --json`, then join the path.
 
-Protocol, in order:
-1. **Claim first**: run `sidequest claim <ref> --by <worker-id> --effort xhigh --project <project>`
-   (add `--effort xhigh` even if the command you were handed omits it). That flag lets the board
-   verify you're the right-tier executor: it refuses the claim if the ticket's derived effort isn't
-   `xhigh` — i.e. the orchestrator spawned the wrong `sidequest-exec-<effort>`. If the claim FAILS
-   for ANY reason (already claimed / done / gone, or an effort mismatch), STOP immediately and report the
-   failure verbatim — do not touch any file. On an effort mismatch the failure names the executor to
-   spawn instead, so the orchestrator can re-route.
-2. **Read yourself in**: read the ticket's description AND its comment thread
-   (`sidequest comments <ref> --project <project>`), plus any linked tickets' threads. A prior or
-   parallel agent may have already mapped the code or left the context you need — don't rediscover it.
-3. **Do exactly the ticket's work** — nothing beyond its scope. No drive-by fixes; if you notice a
-   separate issue, mention it in your report instead of fixing it.
-4. **Verify** your change the way the ticket (or the orchestrator's prompt) specifies — run the
-   syntax check, test, or reproduction it names before declaring success.
-5. **Record findings as a comment**: when the ticket was an investigation/spike, or you learned
-   anything that matters later, write it back with
-   `sidequest comment <ref> -m "..." --project <project>` — root cause with evidence (`file:line`),
-   what you ruled out, the fix, and how you verified. This durable comment (not your orchestrator
-   report) is the deliverable of an investigation. Markdown, real newlines — never a literal `\n`.
-6. **Close**: `sidequest done <ref> --by <same-worker-id> --model <your tier> --effort xhigh --project <project>`
-   — stamp the tier you actually ran as. If you could not finish, `sidequest release <ref> --by
-   <same-worker-id> --status todo` and say why.
+Protocol, per ticket, in order:
+1. **Claim first**: `sidequest claim <ref> --by <worker-id> --effort xhigh --project <project>`
+   (add `--effort xhigh` even if the command you were handed omits it — the board refuses the
+   claim if the ticket's derived effort isn't `xhigh`, i.e. the orchestrator spawned the wrong
+   executor). If the claim FAILS for ANY reason (already claimed / done / gone / effort mismatch), do
+   NOT touch any file for that ticket — in a batch, report the failure and move to the next ref;
+   for a single ticket, stop and report the failure verbatim. On an effort mismatch the failure names
+   the executor to spawn instead, so the orchestrator can re-route.
+2. **Read yourself in**: the ticket's description AND its comment thread
+   (`sidequest comments <ref> --project <project>`), plus any linked tickets' threads — a prior agent
+   may have left the context you need; don't rediscover it. (Skip the thread reads when the
+   orchestrator told you the ticket has no comments — don't fetch empty threads.)
+3. **Do exactly the ticket's work** — nothing beyond its scope. No drive-by fixes; a separate issue
+   you notice goes in your report, not in the diff.
+4. **Verify** the way the ticket (or the orchestrator's prompt) specifies — run the named check/test/
+   reproduction before declaring success.
+5. **Record findings as a comment** when the ticket was an investigation/spike or you learned
+   something that matters later: `sidequest comment <ref> -m "..." --project <project>` — root cause
+   with evidence (`file:line`), what you ruled out, the fix, how you verified. For an investigation
+   this comment (not your report) is the deliverable. Markdown, real newlines — never a literal `\n`.
+6. **Close**: `sidequest done <ref> --by <same-worker-id> --model <your tier> --effort xhigh
+   --project <project>`. Couldn't finish? `sidequest release <ref> --by <same-worker-id> --status
+   todo` and say why. In a batch, then move to the next ref.
 
-**Stuck? Escalate before you thrash.** If the ticket turns out harder or murkier than your tier can
-handle, or two honest attempts haven't moved it, and you have an `advisor` tool available, call it. It
-forwards your full context to a stronger reviewer model, which is a genuine escalation for a low or
-mid-tier executor: you can reach a stronger model this way even when the orchestrator that spawned you
-(often already top-tier) can't use advisor at all. Reach for it when the work is genuinely difficult or
-unclear, before you guess or release. It's an escape hatch, not a routine step, so don't call it on work
-your tier can handle. No `advisor` tool in this environment? Then leave a findings comment and
-`sidequest release <ref> --by <same-worker-id> --status todo` so a higher tier can pick it up.
+**Stuck? Escalate before you thrash.** If a ticket is harder or murkier than your tier can handle, or
+two honest attempts haven't moved it, and an `advisor` tool is available, call it — it forwards your
+context to a stronger reviewer model (a genuine escalation even when your orchestrator can't use
+advisor). It's an escape hatch, not a routine step. No advisor? Leave a findings comment and
+`release --status todo` so a higher tier can pick it up.
 
-Report concretely: claim result, what changed (files/lines), verification output, close confirmation.
-Your final message is returned to the orchestrator — data, not conversation. It is a summary; the
-findings comment on the ticket is the record that persists.
+Report tersely, as data: per ticket — claim result, what changed (files/lines), verification output,
+close confirmation. Your final message returns to the orchestrator; the findings comment on the
+ticket is the record that persists.

--- a/plugins/sidequest/bin/sidequest-mcp.js
+++ b/plugins/sidequest/bin/sidequest-mcp.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * sidequest - MCP server (stdio transport)
+ *
+ * Speaks newline-delimited JSON-RPC 2.0 over stdin/stdout — the MCP stdio
+ * transport — so Claude Code can expose the board as typed tools
+ * (mcp__sidequest__claim, …) instead of an agent shelling out to the CLI per
+ * action. All the logic (tool registry, request handling) is in lib/mcp.js; this
+ * file is just the read-a-line / write-a-line loop.
+ *
+ * One JSON object per line, both directions. We buffer stdin and dispatch on
+ * each complete line; a blank or unparseable line is ignored (a malformed frame
+ * must never crash the server). Node stdlib only.
+ */
+
+const mcp = require('../lib/mcp');
+
+function writeMessage(obj) {
+  if (obj == null) return; // notifications produce no response
+  try {
+    process.stdout.write(JSON.stringify(obj) + '\n');
+  } catch (_) {
+    /* a write failure on a closed pipe shouldn't crash us */
+  }
+}
+
+function handleLine(line) {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  let msg;
+  try {
+    msg = JSON.parse(trimmed);
+  } catch (_) {
+    // Not valid JSON — can't even extract an id to answer, so drop it. A
+    // conforming client never sends this.
+    return;
+  }
+  // A JSON-RPC batch is an array of messages.
+  if (Array.isArray(msg)) {
+    for (const m of msg) writeMessage(mcp.handleRequest(m));
+    return;
+  }
+  writeMessage(mcp.handleRequest(msg));
+}
+
+function main() {
+  let buffer = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk) => {
+    buffer += chunk;
+    let nl;
+    while ((nl = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, nl);
+      buffer = buffer.slice(nl + 1);
+      try {
+        handleLine(line);
+      } catch (_) {
+        /* one bad frame must not take the server down */
+      }
+    }
+  });
+  process.stdin.on('end', () => {
+    // Flush any trailing line without a newline, then exit when the client closes.
+    if (buffer.trim()) {
+      try { handleLine(buffer); } catch (_) { /* ignore */ }
+    }
+    process.exit(0);
+  });
+  // Keep the process alive on stdin; nothing else to do.
+  process.stdin.resume();
+}
+
+main();

--- a/plugins/sidequest/bin/sidequest.js
+++ b/plugins/sidequest/bin/sidequest.js
@@ -71,7 +71,7 @@ function parseArgs(argv) {
         continue;
       }
       // Boolean-ish flags don't consume a value.
-      const BOOL = new Set(['json', 'open', 'help', 'force', 'done', 'archived', 'all', 'dry-run', 'yolo', 'wave']);
+      const BOOL = new Set(['json', 'brief', 'open', 'help', 'force', 'done', 'archived', 'all', 'dry-run', 'yolo', 'wave']);
       if (val === null) {
         if (BOOL.has(key)) {
           opts[key] = true;
@@ -222,14 +222,16 @@ function cmdAdd(opts) {
 
 function cmdList(opts) {
   const { slug, meta } = resolveProject(opts);
+  // --brief is a JSON shape, so it implies --json rather than silently no-oping.
+  if (opts.json || opts.brief) {
+    const payload = store.listPayload(slug, { status: opts.status, archived: opts.archived, brief: opts.brief });
+    process.stdout.write(JSON.stringify(Object.assign({ project: slug, projectName: meta.name }, payload), null, 2) + '\n');
+    return;
+  }
   let tickets = store.listTickets(slug);
   // Archived tickets are hidden from the board by default; `--archived` shows only them.
   tickets = opts.archived ? tickets.filter((t) => t.archived) : tickets.filter((t) => !t.archived);
   if (opts.status) tickets = tickets.filter((t) => t.status === String(opts.status).toLowerCase());
-  if (opts.json) {
-    process.stdout.write(JSON.stringify({ project: slug, projectName: meta.name, tickets }, null, 2) + '\n');
-    return;
-  }
   if (!tickets.length) {
     console.log(`No tickets in ${meta.name}.`);
     return;
@@ -775,13 +777,14 @@ function cmdUnlink(opts, positional) {
 // The set to fan subagents out over: unclaimed, unblocked, not-done, not-archived.
 function cmdReady(opts) {
   const { slug, meta } = resolveProject(opts);
-  const tickets = store.readyTickets(slug, { model: opts.model });
-  const waves = store.readyWaves(slug, { model: opts.model });
-  if (opts.json) {
-    const waveRefs = waves.map((wave) => wave.map((t) => t.ref));
-    process.stdout.write(JSON.stringify({ project: slug, projectName: meta.name, tickets, waves: waveRefs }, null, 2) + '\n');
+  // --brief is a JSON shape, so it implies --json rather than silently no-oping.
+  if (opts.json || opts.brief) {
+    const payload = store.readyPayload(slug, { model: opts.model, brief: opts.brief });
+    process.stdout.write(JSON.stringify(Object.assign({ project: slug, projectName: meta.name }, payload), null, 2) + '\n');
     return;
   }
+  const tickets = store.readyTickets(slug, { model: opts.model });
+  const waves = store.readyWaves(slug, { model: opts.model });
   if (!tickets.length) {
     console.log(`Nothing ready to work in ${meta.name}.`);
     return;
@@ -1333,7 +1336,7 @@ function help() {
 
 Usage:
   sidequest add -t "title" --complexity 1-10 --why "<motivation>" [-d desc] [-p low|normal|high|urgent] [-l label]... [-i image]... [-s todo|doing|done]
-  sidequest list [--status todo|doing|done] [--json]
+  sidequest list [--status todo|doing|done] [--json] [--brief]   (--brief: compact JSON, no bodies; implies --json)
   sidequest update <id|SQ-n> [-t title] [-d desc] [-p priority] [-s status] [-l label]... [-i image]... [--complexity 1-10 --why "<motivation>"]
   sidequest rm <id|SQ-n>
   sidequest projects [--json]
@@ -1345,7 +1348,7 @@ Usage:
     code) — use real newlines in the value (heredoc or $'...\\n...'), never a literal backslash-n.
 
 Working the board safely (multi-agent):
-  sidequest ready [--model tier] [--json]          the ready set (unclaimed, unblocked) — fan subagents over it
+  sidequest ready [--model tier] [--json] [--brief]   the ready set (unclaimed, unblocked) — fan subagents over it
   sidequest claim <id|SQ-n> [--by who] [--force] [--effort level]   atomically take a ticket (fails if gone/done/claimed; --effort must match the derived tier or the claim is refused as wrong-executor)
   sidequest next [--by who] [-p priority] [--model tier]   claim the best available ticket (highest priority first)
   sidequest done <id|SQ-n> [--by who] [--model tier] [--effort level]   mark it done (stamp who/what worked it)

--- a/plugins/sidequest/bin/sidequest.js
+++ b/plugins/sidequest/bin/sidequest.js
@@ -71,7 +71,7 @@ function parseArgs(argv) {
         continue;
       }
       // Boolean-ish flags don't consume a value.
-      const BOOL = new Set(['json', 'open', 'help', 'force', 'done', 'archived', 'all', 'dry-run']);
+      const BOOL = new Set(['json', 'open', 'help', 'force', 'done', 'archived', 'all', 'dry-run', 'yolo', 'wave']);
       if (val === null) {
         if (BOOL.has(key)) {
           opts[key] = true;
@@ -315,6 +315,22 @@ function workerId(opts) {
   );
 }
 
+// The session a claim is taken under, so a SessionEnd / SubagentStop hook can
+// release exactly that session's claims immediately instead of waiting out the
+// TTL (see store.reconcileSession). An explicit --session wins; otherwise fall
+// back to the CLAUDE_SESSION_ID the Claude Code runtime exports to tool/hook
+// subprocesses. Null when neither is present — the whole registry stays dormant
+// and the TTL remains the (unchanged) backstop, so nothing regresses.
+function sessionId(opts) {
+  const v =
+    (opts && opts.session) ||
+    process.env.CLAUDE_CODE_SESSION_ID || // the id the runtime actually exports to tool subprocesses
+    process.env.CLAUDE_SESSION_ID ||      // tolerated legacy/alt spelling
+    process.env.SIDEQUEST_SESSION ||
+    '';
+  return String(v).trim() || null;
+}
+
 function reportClaimFailure(action, idOrRef, res, meta) {
   process.exitCode = 1;
   const c = res.claim || {};
@@ -376,7 +392,7 @@ function cmdClaim(opts, positional) {
     }
     return;
   }
-  const res = store.claimTicket(slug, idOrRef, by, { force: !!opts.force, source: opts.source || 'cli' });
+  const res = store.claimTicket(slug, idOrRef, by, { force: !!opts.force, source: opts.source || 'cli', sessionId: sessionId(opts) });
   if (opts.json) {
     process.stdout.write(JSON.stringify(Object.assign({ project: slug }, res), null, 2) + '\n');
     if (!res.ok) process.exitCode = 1;
@@ -395,7 +411,7 @@ function cmdRelease(opts, positional) {
   if (!idOrRef) fail('release: pass a ticket id or ref, e.g. sidequest release SQ-3');
   const { slug, meta } = resolveProject(opts);
   const by = workerId(opts);
-  const res = store.releaseTicket(slug, idOrRef, by, { force: !!opts.force, status: opts.status, source: opts.source || 'cli' });
+  const res = store.releaseTicket(slug, idOrRef, by, { force: !!opts.force, status: opts.status, source: opts.source || 'cli', sessionId: sessionId(opts) });
   if (opts.json) {
     process.stdout.write(JSON.stringify(Object.assign({ project: slug }, res), null, 2) + '\n');
     if (!res.ok) process.exitCode = 1;
@@ -419,6 +435,7 @@ function cmdDone(opts, positional) {
       source: opts.source || 'cli',
       model: opts.model,
       effort: opts.effort,
+      sessionId: sessionId(opts),
     });
   } catch (e) {
     fail(`done: ${(e && e.message) || e}`);
@@ -435,7 +452,7 @@ function cmdDone(opts, positional) {
 function cmdNext(opts) {
   const { slug, meta } = resolveProject(opts);
   const by = workerId(opts);
-  const res = store.claimNext(slug, by, { priority: opts.priority, model: opts.model, source: opts.source || 'cli' });
+  const res = store.claimNext(slug, by, { priority: opts.priority, model: opts.model, source: opts.source || 'cli', sessionId: sessionId(opts) });
   if (opts.json) {
     process.stdout.write(JSON.stringify(Object.assign({ project: slug }, res), null, 2) + '\n');
     if (!res.ok) process.exitCode = 1;
@@ -449,6 +466,78 @@ function cmdNext(opts) {
     process.exitCode = 1;
     console.log(`No available tickets to claim in ${meta.name}.`);
   }
+}
+
+// Drain the ready set with headless `claude -p` runs, one per ready ticket at
+// its derived tier (see lib/work.js). --dry-run prints the plan without spawning.
+async function cmdWork(opts) {
+  const { slug, meta } = resolveProject(opts);
+  const work = require('../lib/work');
+  const wopts = {
+    max: opts.max,
+    maxWaves: opts['max-waves'],
+    model: opts.model,
+    singleWave: !!opts.wave,
+    yolo: !!opts.yolo,
+    permissionMode: opts['permission-mode'],
+  };
+
+  if (opts['dry-run']) {
+    const { plan, waveCount, dropped } = work.planWork(slug, wopts);
+    if (opts.json) {
+      process.stdout.write(JSON.stringify({ project: slug, waveCount, dropped, plan }, null, 2) + '\n');
+      return;
+    }
+    if (!plan.length) {
+      console.log(`No ready tickets to work in ${meta.name}. Board is drained.`);
+      return;
+    }
+    console.log(`Would launch ${plan.length} headless run(s) for wave 1 of ${waveCount} in ${meta.name}${dropped ? ` (${dropped} more this wave over --max)` : ''}:`);
+    for (const p of plan) {
+      console.log(`  ${p.ref}  →  claude --model ${p.tier}${p.effort ? `  (derived effort ${p.effort}; headless runs at model default)` : ''}  --by ${p.by}`);
+    }
+    console.log(`\n(dry run — nothing was spawned. Drop --dry-run to launch; ${work.claudeAvailable() ? 'claude CLI found' : 'WARNING: claude CLI not on PATH'}.)`);
+    return;
+  }
+
+  const res = await work.runWork(slug, wopts, (line) => console.log(line));
+  if (!res.ok) {
+    fail(`work: ${res.message || res.reason}`);
+  }
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(Object.assign({ project: slug }, res), null, 2) + '\n');
+    return;
+  }
+  if (!res.wavesRun) {
+    console.log(`No ready tickets to work in ${meta.name}. Board is drained.`);
+    return;
+  }
+  const okc = res.results.filter((r) => r.ok).length;
+  console.log(`\nHeadless drain finished: ${res.wavesRun} wave(s), ${okc}/${res.results.length} run(s) exited clean.`);
+  for (const r of res.results) {
+    console.log(`  ${r.ref}: ${r.ok ? '✓ ok' : `✗ ${r.error || 'exit ' + r.code}`}`);
+  }
+}
+
+// Release every claim a session left behind (moving each ticket back to todo),
+// immediately instead of waiting out the claim TTL. Called by the SessionEnd
+// hook with the ending session's id; safe to run by hand too.
+// Session-scoped by construction (see store.reconcileSession) — it only touches
+// claims the registry attributes to THIS session. No session id -> a clean no-op.
+function cmdReconcile(opts) {
+  const sid = sessionId(opts);
+  const reason = opts.reason || 'worker session ended';
+  const res = store.reconcileSession(sid, { reason, source: opts.source || 'cli' });
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(Object.assign({ session: sid }, res), null, 2) + '\n');
+    return;
+  }
+  if (!sid) {
+    console.log('reconcile: no session id (pass --session or set CLAUDE_SESSION_ID) — nothing to do.');
+    return;
+  }
+  if (res.released.length) console.log(`✓ reconciled ${sid}: released ${res.released.join(', ')} back to todo.`);
+  else console.log(`✓ reconciled ${sid}: no outstanding claims to release.`);
 }
 
 // Assign a ticket to someone (defaults to the human "you"), or clear it with
@@ -1282,6 +1371,18 @@ Complexity → routing (score the task; model + effort are derived, never tagged
   Sidequest can't force a model or effort — it records the score and derives the tag (⚙C<n>→tier·effort on
   list/ready); the orchestrator routes by reading it. Haiku rungs have no effort.
 
+Headless / autonomous draining (work the board without an interactive session):
+  sidequest work [--dry-run] [--max N=3] [--max-waves N=5] [--model tier] [--wave] [--yolo] [--permission-mode M]
+    Spawns one headless \`claude -p\` run per ready ticket at its derived tier, wave by wave, until the
+    board is drained. --dry-run prints the plan (spawns nothing). --wave does a single wave. --yolo maps to
+    --dangerously-skip-permissions; otherwise runs at --permission-mode (default acceptEdits). Effort isn't
+    settable headless, so a run carries the ticket's MODEL and runs at that model's default effort. Safe
+    beside an interactive session — claiming stays atomic. Needs the \`claude\` CLI on PATH.
+  sidequest reconcile [--session <id>] [--reason "..."]   release a session's stale claims back to todo now
+    (the SessionEnd hook calls this automatically on the session id it's given, so a crashed/ended worker's
+    tickets recover immediately instead of waiting out the claim TTL; safe — it only touches that session's
+    claims). Defaults to \$CLAUDE_CODE_SESSION_ID when --session is omitted.
+
 Assigning (persistent owner, e.g. handing a ticket to the human — separate from a claim):
   sidequest assign <id|SQ-n> [--to who=you]        assign a ticket (defaults to "you", the human)
   sidequest unassign <id|SQ-n>                      clear the assignee
@@ -1386,6 +1487,13 @@ async function main() {
     case 'next':
     case 'grab':
       cmdNext(opts);
+      break;
+    case 'reconcile':
+      cmdReconcile(opts);
+      break;
+    case 'work':
+    case 'drain':
+      await cmdWork(opts);
       break;
     case 'done':
     case 'complete':

--- a/plugins/sidequest/hooks/capture-nudge.js
+++ b/plugins/sidequest/hooks/capture-nudge.js
@@ -17,6 +17,14 @@
  * is one quick step. The decision to file stays with Claude (the instruction is
  * conditional), so an ordinary prompt about the current task creates no ticket.
  *
+ * Token diet (2026-07): every block this hook emits lands as UNCACHED context on
+ * the turn it fires and then sits in the transcript for the rest of the session,
+ * so per-prompt output is the single most expensive surface the plugin has. The
+ * no-marker standing reminder is therefore one short line (the full doctrine
+ * lives in the SessionStart hook, which re-fires on compact/resume, and in the
+ * skill), and the marker-gated blocks are kept tight. Don't grow them back:
+ * hooks.test.js enforces byte budgets on each block.
+ *
  * Design constraints (shared with the rest of the toolshed):
  *   - Node stdlib only, cross-platform.
  *   - Fail-soft: any error -> exit 0 with no output. It must never break a prompt.
@@ -142,21 +150,15 @@ function emit(context) {
   );
 }
 
-// A compact restatement of the plan + fan-out discipline. The full standing
-// reminder only fires on prompts with no capture/board-mgmt marker — but the
-// prompts that KICK OFF real multi-part work are the ones most likely to trip a
-// defect/interjection marker ("fix the broken X, also wire up Y"), which used to
-// swap in the capture or board-control block and drop the fan-out guidance
-// entirely. So we append this footer to those blocks too: the specific block
-// still leads, but the discipline is never fully suppressed.
-function coreDisciplineFooter() {
+// One short line restating the execution discipline, appended to the
+// marker-gated blocks so an action prompt that trips capture/board-control
+// doesn't lose it entirely. Deliberately tiny — the full version lives in the
+// SessionStart hook and the skill.
+function disciplineFooter() {
   return (
-    '\n\n— sidequest discipline still applies: plan multi-part work as tickets first, and ALWAYS fan out ' +
-    'with NAMED subagents by default (never anonymous/generic teammates) — a named scout before you read ' +
-    '~4+ files, independent ready tickets as named parallel executors — rather than grinding serially. For ' +
-    'a larger/repeatable run a WORKFLOW (agent()/parallel()/pipeline(), sized small <5 / medium <15 / ' +
-    'large <50) fits, but it\'s opt-in: PROPOSE it via AskUserQuestion when you judge it helps, don\'t ' +
-    'launch one unprompted.'
+    '\n— sidequest: plan multi-part work as tickets first; route execution to each ticket\'s stamped ' +
+    '(cheap) tier as short, bounded executor runs — batch small same-tier tickets, parallelize ' +
+    'independent ones; inline only trivial one-steps.'
   );
 }
 
@@ -173,41 +175,16 @@ function main() {
 
   const cli = `node "${path.join(pluginRoot(), 'bin', 'sidequest.js')}"`;
 
-  // No capture/board signal in this message: keep a short standing reminder in
-  // front of Claude (unless opted out) so it actually uses sidequest rather than
-  // forgetting the system is here. The heavier blocks below fire on a match.
+  // No capture/board signal in this message: one short standing line (unless
+  // opted out) so the board isn't forgotten mid-session. The full doctrine is
+  // NOT repeated here — SessionStart injects it once per session (and again on
+  // compact/resume), and the sidequest skill carries the details.
   if (!isCapture && !isMgmt) {
     if (nudgeOff()) process.exit(0);
     emit(
-      '=== sidequest (active) ===\n' +
-        'Track work on the board; don\'t keep the plan only in your head.\n' +
-        'Even if this repo uses an external tracker (Jira/Linear/GitHub Issues), that tracks the ' +
-        'deliverable — sidequest is still your LOCAL execution layer here (decompose, fan out, run ' +
-        'subagents). Use it anyway; don\'t skip it because the work is "already tracked". See the sidequest ' +
-        'skill for why/how the two coexist.\n' +
-        '• CAPTURE a bug/task/idea SEPARATE from your current work as a ticket right away (bg `ticket-filer` ' +
-        'agent, or `' + cli + ' add`).\n' +
-        '• PLAN substantial/multi-part work as one ticket per piece FIRST, link deps, score each — not ad hoc.\n' +
-        '• EXECUTE off the main thread — by default as NAMED subagents (turn-by-turn, addressable/' +
-        'resumable): each ticket is complexity-scored and routed to the best model×effort for it, so spawn ' +
-        'its executor as a NAMED subagent (`sidequest-exec-<effort>` + the ticket\'s model, unique ' +
-        'lowercase-hyphen name) to claim → do → `done` — the name makes it addressable/resumable via ' +
-        'SendMessage. Doing it in the main thread throws that routing away. For many independent tickets or ' +
-        'a repeatable structured run, a WORKFLOW (script-driven, sized by complexity) fits — but it\'s ' +
-        'opt-in: PROPOSE it via AskUserQuestion (why + scale + token cost) when you judge it helps, rather ' +
-        'than launching one unprompted. ~95% of real work should run off the main thread; the main thread ' +
-        'orchestrates and only does genuinely trivial changes itself.\n' +
-        '• FAN OUT: ALWAYS fan out using NAMED subagents — NAME every subagent you spawn (unique ' +
-        'lowercase-hyphen name), never anonymous/generic teammates. About to read ~4+ files or grep a ' +
-        'subsystem to understand it? Spawn one or more NAMED scouts concurrently in a single message FIRST ' +
-        '(each isolated + resumable; built-in Explore/Plan are one-shot, so prefer a general-purpose or ' +
-        'custom named agent like code-explorer for resumable work). Run independent ready tickets as NAMED ' +
-        'parallel executors (claim first, distinct `--by`); for larger/repeatable orchestration PROPOSE a ' +
-        'WORKFLOW (opt-in, via AskUserQuestion) sized small (<5) / medium (<15) / large (<50). Keep ' +
-        'dependent/same-file work serial.\n' +
-        '• RECORD an investigation as a ticket and write findings back as a comment (`' + cli +
-        ' comment <ref>`); READ a ticket\'s comments before working it.\n' +
-        'Board: `' + cli + ' dashboard`.'
+      '=== sidequest (active) === Plan multi-part work as tickets on the board; capture side issues as ' +
+        'tickets (background `ticket-filer`). Route execution to each ticket\'s stamped cheap tier as ' +
+        'short, bounded executor runs. See the sidequest skill.'
     );
     process.exit(0);
   }
@@ -218,22 +195,15 @@ function main() {
   if (isMgmt && !strongCapture) {
     emit(
       '=== sidequest — board control ===\n' +
-        'Use the sidequest CLI to view or manage the board (absolute path resolved for you). ' +
-        'Run these with the Bash tool:\n' +
-        `  Open the live board in the browser:  ${cli} dashboard\n` +
-        `  List tickets on this project:        ${cli} list\n` +
-        `  Move / edit a ticket:                ${cli} update SQ-3 --status done   (status: todo|doing|done; also -p, -t, -d, -l)\n` +
-        `  Remove a ticket:                     ${cli} rm SQ-3\n` +
-        `  List every project's board:          ${cli} projects\n` +
-        '\nTo WORK a ticket safely (other agents may share this board): claim it FIRST, then work, then finish.\n' +
-        `  ${cli} claim SQ-3 --by <you>   (or ${cli} next --by <you> to grab the top-priority ticket)\n` +
-        `  ${cli} done SQ-3 --by <you>    when finished  ·  ${cli} release SQ-3 --by <you>  to drop it\n` +
-        'Claiming is atomic: if it fails (already claimed / done / gone) do NOT work the ticket — pick another. ' +
-        'For a small ticket you may spawn a subagent to do the work, but only AFTER the claim succeeds.\n' +
-        'Tickets are stored centrally, so `dashboard` shows every project at once. To open the board, ' +
-        'just run the dashboard command — it starts the local server if needed and opens the browser, ' +
-        'then report the URL it prints.' +
-        coreDisciplineFooter()
+        'Prefer the mcp__plugin_sidequest_board__* tools for board actions when available; otherwise the ' +
+        'CLI below (Bash tool, absolute path already resolved):\n' +
+        `  ${cli} dashboard    — open the live board; report the URL it prints\n` +
+        `  ${cli} list         — this project's tickets (--json to read; add --brief for a compact read)\n` +
+        `  ${cli} update SQ-3 --status done    — move/edit (also -p, -t, -d, -l) · rm SQ-3 — delete\n` +
+        'To WORK a ticket, claim it FIRST: `claim SQ-3 --by <you>` (or `next --by <you>`), then work, then ' +
+        '`done SQ-3 --by <you>` (`release` to drop it). Claiming is atomic — if it fails, do NOT work that ' +
+        'ticket; pick another.' +
+        disciplineFooter()
     );
     process.exit(0);
   }
@@ -253,23 +223,18 @@ function main() {
 
   const context =
     '=== sidequest — capture the side quest ===\n' +
-    'If this message raised an issue, bug, or task SEPARATE from what you are currently doing, ' +
-    'capture it as a ticket right now so it is not lost, then carry on with your current task ' +
-    'without derailing it. (If the message is only about the task you are already on, ignore this.)\n' +
-    '\n' +
-    'Preferred: spawn the `ticket-filer` subagent in the BACKGROUND (run_in_background: true) so your ' +
-    'current work is not interrupted. Give it a short title, a one-line description, a priority ' +
-    '(low|normal|high|urgent), any labels, and any pasted image path.\n' +
-    '\n' +
-    'Or file it directly in one command:\n' +
+    'If this message raised an issue/task SEPARATE from what you are currently doing, capture it as a ' +
+    'ticket right now, then carry on without derailing. (If it is only about the current task, ignore ' +
+    'this.)\n' +
+    'Preferred: spawn the `ticket-filer` subagent in the BACKGROUND (run_in_background: true) with a short ' +
+    'title, a one-line description, a priority, any labels, and any pasted image path. Or file directly:\n' +
     `  ${cli} add -t "Short title" -d "What is wrong" -p high -l bug --complexity <1-10> --why "<motivation>"` +
     (images.length ? ` -i "${images[0]}"` : '') +
     '\n' +
-    '  (both required — score 1-10 by real task complexity and motivate it in one concrete sentence; routing is derived)\n' +
     imageHint +
-    'Do NOT ask permission first and do NOT stop your current task to do this — capture, then continue. ' +
-    'Say one short line noting the ticket ref (e.g. "filed SQ-5") when done.' +
-    coreDisciplineFooter();
+    'Do NOT ask permission and do NOT stop your current task — capture, then continue; note the ref ' +
+    '(e.g. "filed SQ-5") in one short line.' +
+    disciplineFooter();
 
   emit(context);
   process.exit(0);

--- a/plugins/sidequest/hooks/hooks.json
+++ b/plugins/sidequest/hooks/hooks.json
@@ -22,6 +22,17 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/session-end.js\"",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/sidequest/hooks/session-end.js
+++ b/plugins/sidequest/hooks/session-end.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * sidequest - SessionEnd hook: release this session's claims immediately
+ *
+ * A claim carries a TTL (default 60 min) so a crashed worker's ticket eventually
+ * frees up. But when a whole SESSION ends we KNOW its claims are dead right then —
+ * no reason to make a dependent ticket wait out the TTL. This hook fires on that
+ * boundary, reads the ending session's id, and asks the store to release exactly
+ * the claims that session took (moving each ticket back to `todo`), so the ready
+ * pool recovers instantly.
+ *
+ * It is SAFE by construction: store.reconcileSession only touches claims the
+ * worker registry attributes to THIS session id, skips anything already done or
+ * re-claimed by another session, and is a no-op for an unknown/absent id. The TTL
+ * stays the untouched backstop for anything the registry never saw.
+ *
+ * Design constraints (shared with the rest of the toolshed):
+ *   - Node stdlib only, cross-platform.
+ *   - Fail-soft: any error -> exit 0 with no output. It must never break session teardown.
+ */
+
+const path = require('path');
+
+function readStdin() {
+  try {
+    const fs = require('fs');
+    const raw = fs.readFileSync(0, 'utf8');
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function pluginRoot() {
+  return process.env.CLAUDE_PLUGIN_ROOT || path.join(__dirname, '..');
+}
+
+function main() {
+  const data = readStdin();
+  if (!data) process.exit(0);
+  const sessionId = data.session_id || data.sessionId || process.env.CLAUDE_CODE_SESSION_ID || process.env.CLAUDE_SESSION_ID || '';
+  if (!sessionId) process.exit(0); // nothing to attribute claims to
+
+  const reason = data.reason ? `session ended (${data.reason})` : 'session ended';
+  let store;
+  try {
+    store = require(path.join(pluginRoot(), 'lib', 'store.js'));
+  } catch (_) {
+    process.exit(0); // can't load the store -> the TTL still covers everything
+  }
+  try {
+    store.reconcileSession(String(sessionId), { reason, source: 'session-end' });
+  } catch (_) {
+    /* best effort */
+  }
+  process.exit(0);
+}
+
+try {
+  main();
+} catch (_) {
+  process.exit(0);
+}

--- a/plugins/sidequest/hooks/session-start.js
+++ b/plugins/sidequest/hooks/session-start.js
@@ -7,8 +7,18 @@
  * code instead of planning as tickets. This hook fires once when a session
  * begins and drops a short standing reminder in front of Claude: unless the
  * request is trivial, plan it as sidequest tickets (complexity-scored per the
- * skill) and route execution through executor subagents, rather than working
- * ad hoc. It is a nudge, not a gate — Claude is free to ignore it for small asks.
+ * skill) and route execution proportionally. It is a nudge, not a gate — Claude
+ * is free to ignore it for small asks.
+ *
+ * Token diet (2026-07): this block is the ONE place the execution doctrine gets
+ * injected (the per-prompt hook only emits a one-liner), so it carries the
+ * delegation rules — but tightly. The economy is expensive-orchestrator /
+ * cheap-executors: real execution routes DOWN to each ticket's stamped tier
+ * (inline only a trivial one-step change), and the cost control is the SHAPE of
+ * the runs, not pulling work onto the pricey main thread — short bounded
+ * executor runs that bounce back fast, batching small same-tier tickets into
+ * one spawn, --brief board reads. hooks.test.js enforces a byte budget on this
+ * block — don't grow it back.
  *
  * Design constraints (shared with the rest of the toolshed):
  *   - Node stdlib only, cross-platform.
@@ -60,50 +70,43 @@ function main() {
   // This hook intentionally fires on EVERY SessionStart source (startup, resume,
   // clear, compact) rather than filtering any of them out: standing context does
   // not survive compaction, so it has to re-inject each time the session context
-  // gets rebuilt. compact/resume just get a terser re-grounding block below
-  // instead of the full nudge, since the fuller guidance already ran once this
-  // session and the per-prompt reminder will fire again on the very next prompt.
+  // gets rebuilt. compact/resume just get a terser re-grounding block below.
   const source = typeof data.source === 'string' ? data.source : '';
 
   if (source === 'compact' || source === 'resume') {
     emit(
       '=== sidequest (active — context restored) ===\n' +
-        'sidequest is still active for this project — context was just compacted/resumed, so ' +
-        'RE-CHECK in-flight claims: `' + cli + ' list --status doing`.\n' +
-        'The discipline still applies: plan as tickets, ALWAYS fan out using NAMED subagents (every spawned ' +
-        'agent gets a unique name so it\'s addressable/resumable) as the default parallelizer, and when a ' +
-        'larger/repeatable run would help, PROPOSE a script-driven WORKFLOW (opt-in — offer it via ' +
-        'AskUserQuestion) sized small <5 / medium <15 / large <50 — ~95% of real work runs off the main ' +
-        'thread.\n' +
-        'The full per-prompt reminder returns on your next prompt.\n'
+        'Context was just compacted/resumed — RE-CHECK in-flight claims: `' + cli + ' list --status doing`.\n' +
+        'Discipline: plan multi-part work as tickets; route execution to each ticket\'s stamped (cheap) ' +
+        'tier as short, bounded executor runs — batch small same-tier tickets; inline only trivial ' +
+        'one-steps.'
     );
     process.exit(0);
   }
 
   emit(
     '=== sidequest (active) ===\n' +
-      'This project tracks work in sidequest — use the board, do not keep the plan only in your head.\n' +
-      'Even if this repo uses an external tracker (Jira/Linear/GitHub Issues), that tracks the deliverable — ' +
-      'sidequest is still your LOCAL execution layer here (decompose, fan out into NAMED subagents, or drive ' +
-      'a workflow). Use it anyway; don\'t skip it because the work is "already tracked". See the sidequest ' +
-      'skill for why/how they coexist.\n' +
-      'Unless this request is trivial, plan it as tickets on the board (complexity-scored per the sidequest ' +
-      'skill) before implementing, then route execution off the main thread — each ticket is scored and ' +
-      'routed to the best model×effort, and that same complexity ALSO picks the orchestration shape: ' +
-      '(1) by default spawn a NAMED routed subagent per ticket (unique lowercase-hyphen name, never anonymous ' +
-      '— claim → do → done) so it\'s addressable, resumable via SendMessage, and trackable in the fleet view; ' +
-      '(2) for a larger or repeatable structured run, a WORKFLOW (agent()/parallel()/pipeline(), sized small ' +
-      '<5 / medium <15 / large <50) fits — but it\'s opt-in, so PROPOSE it via AskUserQuestion (explain why, ' +
-      'the scale, the token cost) rather than launching one unprompted; you judge better than the user when ' +
-      'one helps, so don\'t stay silent. ~95% of real work should run off the main thread; the main thread ' +
-      'orchestrates the team.\n' +
-      'FAN OUT BY DEFAULT: about to read ~4+ files or grep a subsystem to understand it? Spawn one or more ' +
-      'NAMED scouts concurrently in a single message FIRST — each named, isolated, independently resumable ' +
-      '(built-in Explore/Plan are one-shot, so use a general-purpose or custom named agent like code-explorer ' +
-      'when the scout must be resumable). Run independent ready tickets as NAMED parallel executors (claim ' +
-      'first, distinct `--by`); for a large independent batch, PROPOSE a WORKFLOW (opt-in, via ' +
-      'AskUserQuestion) rather than hand-spawning one at a time; keep dependent/same-file work serial.\n' +
-      'Board: `' + cli + ' dashboard`.'
+      'This project tracks work on the sidequest board — plan any multi-part request as small ATOMIC ' +
+      'tickets BEFORE implementing (each needs --complexity 1-10 + --why; model×effort routing is ' +
+      'derived from the score). Atomic = one concrete change the executor can finish without ' +
+      'discovering anything; the spec carries the context. Even if the repo uses an external tracker ' +
+      '(Jira/Linear/GitHub Issues), that owns the deliverable — sidequest is the local execution layer; ' +
+      'use both.\n' +
+      'Execution economy — expensive orchestrator, cheap executors, tight loop:\n' +
+      '• Route real execution DOWN to each ticket\'s stamped tier: spawn `sidequest-exec-<effort>` + the ' +
+      'ticket\'s model + a unique lowercase-hyphen name. This thread (usually the priciest model) ' +
+      'orchestrates — decompose, score, spec, spawn, integrate. Inline only a trivial one-step change.\n' +
+      '• Keep executor runs SHORT and bounded — the ticket is the spec (exact anchors + verify command); ' +
+      'scope the spawn prompt; executors bounce back fast (release + report) instead of wandering. Many ' +
+      'short orchestrator↔executor round-trips beat one long autonomous run. Verify reports by artifact ' +
+      '(test output/diff), not by claim.\n' +
+      '• Batch several small SAME-tier tickets into ONE executor (sequential inside); independent tickets ' +
+      'big enough for a spawn each run as a PARALLEL wave (`ready --json --brief`, one executor per ' +
+      'ticket, one message).\n' +
+      'Capture side issues the user mentions as tickets (background `ticket-filer`) without derailing ' +
+      'the current task.\n' +
+      'Board: `' + cli + ' dashboard` — prefer the mcp__plugin_sidequest_board__* tools for board ' +
+      'actions when available.'
   );
   process.exit(0);
 }

--- a/plugins/sidequest/lib/mcp.js
+++ b/plugins/sidequest/lib/mcp.js
@@ -1,0 +1,507 @@
+'use strict';
+/**
+ * sidequest - MCP tool layer
+ *
+ * A second entry point over the same store as the CLI, so an agent working the
+ * board calls typed tools (mcp__sidequest__claim, …) instead of shelling out to
+ * `node bin/sidequest.js …` on every action. What that buys:
+ *   - one permission grant for the whole toolset instead of a Bash prompt per call,
+ *   - structured JSON in and out (no stdout parsing, no literal-\n heredoc trap on
+ *     multi-line descriptions), and
+ *   - a smaller skill, because the tool schemas are self-describing.
+ *
+ * This file is pure logic: a tool registry plus a JSON-RPC request handler. The
+ * transport (a newline-delimited stdio loop) lives in bin/sidequest-mcp.js, and
+ * the tests drive handleRequest() directly. Node stdlib only — no MCP SDK, so the
+ * plugin stays dependency-free; the stdio JSON-RPC surface is tiny enough to
+ * implement by hand.
+ *
+ * Every tool resolves its target board exactly like the CLI (CLAUDE_PROJECT_DIR
+ * or cwd -> nearest repo root -> ensureProject; an explicit `project` arg -> the
+ * registered board it names), so the CLI, the dashboard, and these tools all act
+ * on the same store.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const store = require('./store');
+
+const SERVER_NAME = 'sidequest';
+// The latest MCP protocol revision we implement. In `initialize` we echo the
+// client's requested version when it sends one (maximizes compatibility) and
+// fall back to this otherwise.
+const DEFAULT_PROTOCOL_VERSION = '2025-06-18';
+
+function serverVersion() {
+  try {
+    return require('../.claude-plugin/plugin.json').version || '0.0.0';
+  } catch (_) {
+    return '0.0.0';
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ *  Project resolution (a non-exiting mirror of the CLI's resolveProject)
+ * ------------------------------------------------------------------ */
+
+function resolveProject(projectArg) {
+  const arg = projectArg == null ? '' : String(projectArg).trim();
+  if (arg) {
+    const res = store.findProject(arg);
+    if (res.ok) return { slug: res.slug, meta: res.meta };
+    if (res.reason === 'ambiguous') {
+      throw new Error(`project "${arg}" matches ${res.matches.length} boards named "${arg}" — pass the absolute path to disambiguate.`);
+    }
+    if (path.isAbsolute(arg)) {
+      let isDir = false;
+      try { isDir = fs.statSync(arg).isDirectory(); } catch (_) { /* not a dir */ }
+      if (isDir) return store.ensureProject(store.nearestRepoRoot(path.resolve(arg)));
+    }
+    const known = Array.from(new Set(res.known || []));
+    throw new Error(`project "${arg}" does not match any registered board.${known.length ? ' Known: ' + known.join(', ') : ''}`);
+  }
+  const start = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  return store.ensureProject(store.nearestRepoRoot(start));
+}
+
+// The session a claim is taken under (so a SessionEnd hook can release it fast).
+// The server process inherits CLAUDE_SESSION_ID from the runtime; an explicit
+// arg overrides. Null when neither is present (registry stays dormant, TTL covers).
+function sessionOf(args) {
+  const v = (args && args.session) || process.env.CLAUDE_CODE_SESSION_ID || process.env.CLAUDE_SESSION_ID || '';
+  return String(v).trim() || null;
+}
+
+// A worker identity is required for claim/next/done/release — a generic shared
+// value silently defeats the atomic-claim guarantee (two sessions both "claude"
+// each think they own the ticket), so we don't invent a default here.
+function requireBy(args, action) {
+  const by = args && args.by != null ? String(args.by).trim() : '';
+  if (!by) throw new Error(`${action}: "by" is required — a unique per-worker id (e.g. claude-<8 hex>). A shared value breaks the atomic-claim guarantee.`);
+  return by;
+}
+
+/* ------------------------------------------------------------------ *
+ *  Effort-drift guard (mirrors bin/sidequest.js effortDriftReason)
+ *
+ *  Kept in lockstep with the CLI's copy: an executor claiming with a baked
+ *  --effort that doesn't match the ticket's derived effort means the wrong-tier
+ *  agent was spawned, so the claim is refused before it mutates anything.
+ * ------------------------------------------------------------------ */
+
+function effortDrift(slug, idOrRef, claimedEffort) {
+  if (claimedEffort == null) return null;
+  const prefs = store.getModelPrefs();
+  if (prefs.routing === false) return null;
+  const t = store.getTicket(slug, idOrRef);
+  if (!t || !t.complexity) return null;
+  if (t.model === 'haiku' || !t.effort) return null;
+  const claimed = String(claimedEffort).toLowerCase();
+  if (claimed === t.effort) return null;
+  return {
+    reason: 'effort_mismatch',
+    ref: t.ref,
+    derivedModel: t.model,
+    derivedEffort: t.effort,
+    claimedEffort: claimed,
+    message: `${t.ref} derives to ${t.model}·${t.effort} — spawn sidequest-exec-${t.effort}, not an exec-${claimed}. Claim refused.`,
+  };
+}
+
+/* ------------------------------------------------------------------ *
+ *  Tools
+ *
+ *  Each: { name, description, inputSchema (JSON Schema), handler(args)->object }.
+ *  A handler returns a plain object; the caller serializes it to a JSON text
+ *  content block. A thrown Error becomes an isError tool result the model reads.
+ * ------------------------------------------------------------------ */
+
+const PROJECT_PROP = { type: 'string', description: 'Board to target (a registered slug, display name, or absolute path). Omit for the current project.' };
+
+const TOOLS = [
+  {
+    name: 'list',
+    description: 'List tickets on a board, grouped data for the caller to read. Add status to filter one column; archived:true shows archived tickets.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project: PROJECT_PROP,
+        status: { type: 'string', enum: ['todo', 'doing', 'done'] },
+        archived: { type: 'boolean' },
+      },
+    },
+    handler(args) {
+      const { slug, meta } = resolveProject(args.project);
+      let tickets = store.listTickets(slug);
+      tickets = args.archived ? tickets.filter((t) => t.archived) : tickets.filter((t) => !t.archived);
+      if (args.status) tickets = tickets.filter((t) => t.status === String(args.status).toLowerCase());
+      return { project: slug, projectName: meta.name, tickets };
+    },
+  },
+  {
+    name: 'ready',
+    description: 'The fan-out set: unclaimed, unblocked, not-done tickets, partitioned into parallel-safe waves by declared file scope. Spawn one executor per ticket in wave 1. model filters to one derived tier.',
+    inputSchema: {
+      type: 'object',
+      properties: { project: PROJECT_PROP, model: { type: 'string', enum: store.VALID_MODELS } },
+    },
+    handler(args) {
+      const { slug, meta } = resolveProject(args.project);
+      const waves = store.readyWaves(slug, { model: args.model });
+      const tickets = store.readyTickets(slug, { model: args.model });
+      return { project: slug, projectName: meta.name, waves, tickets };
+    },
+  },
+  {
+    name: 'add',
+    description: 'File a new ticket. complexity (1-10) and why (a real motivation, min 20 chars) are BOTH required — routing (model+effort) is derived from the score; model/effort are never set directly. description is a developer-to-developer spec (Where / Contract / Bounds / Verify), passed as a normal string (real newlines fine — no shell escaping).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project: PROJECT_PROP,
+        title: { type: 'string' },
+        description: { type: 'string' },
+        priority: { type: 'string', enum: store.VALID_PRIORITY },
+        status: { type: 'string', enum: store.VALID_STATUS },
+        labels: { type: 'array', items: { type: 'string' } },
+        files: { type: 'array', items: { type: 'string' }, description: 'Declared file scope (paths or dir prefixes) for parallel-wave planning.' },
+        story: { type: 'string', description: 'A story ref (US-n) to file this ticket into.' },
+        complexity: { type: 'integer', minimum: 1, maximum: 10 },
+        why: { type: 'string', description: 'Motivation for the complexity score, against the actual task (min 20 chars).' },
+      },
+      required: ['title', 'complexity', 'why'],
+    },
+    handler(args) {
+      if (!args.title || !String(args.title).trim()) throw new Error('add: title is required.');
+      if (args.model != null || args.effort != null) throw new Error('add: model/effort are not set directly — score the task with complexity + why and routing is derived.');
+      if (store.coerceComplexity(args.complexity) == null) throw new Error('add: complexity is required — an integer 1-10 (absolute scale: 1 = summarize a README, ~5 = simple HTML, 10 = frontier AI research).');
+      if (!args.why || String(args.why).trim().length < 20) throw new Error('add: why is required (min 20 chars) — motivate the complexity against the real task.');
+      const { slug, meta } = resolveProject(args.project);
+      const created = store.createTicket(slug, {
+        title: args.title,
+        description: args.description || '',
+        priority: args.priority,
+        status: args.status,
+        labels: args.labels,
+        files: args.files,
+        storyId: args.story,
+        complexity: args.complexity,
+        complexityWhy: args.why,
+        source: 'mcp',
+      });
+      const ticket = store.getTicket(slug, created.ref) || created;
+      return { ok: true, project: slug, projectName: meta.name, ticket };
+    },
+  },
+  {
+    name: 'update',
+    description: 'Edit a ticket by ref. Any omitted field is left unchanged. Re-scoring needs both complexity and a fresh why. Set story to "none" to detach. model/effort are not accepted.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string' },
+        project: PROJECT_PROP,
+        title: { type: 'string' },
+        description: { type: 'string' },
+        priority: { type: 'string', enum: store.VALID_PRIORITY },
+        status: { type: 'string', enum: store.VALID_STATUS },
+        labels: { type: 'array', items: { type: 'string' } },
+        files: { type: 'array', items: { type: 'string' } },
+        story: { type: 'string' },
+        complexity: { type: 'integer', minimum: 1, maximum: 10 },
+        why: { type: 'string' },
+      },
+      required: ['ref'],
+    },
+    handler(args) {
+      if (args.model != null || args.effort != null) throw new Error('update: model/effort are not accepted — routing is derived from complexity.');
+      if (args.complexity != null && (!args.why || String(args.why).trim().length < 20)) {
+        throw new Error('update: re-scoring complexity needs a fresh why (min 20 chars).');
+      }
+      const { slug, meta } = resolveProject(args.project);
+      const patch = { source: 'mcp' };
+      for (const k of ['title', 'description', 'priority', 'status', 'labels', 'files', 'complexity']) {
+        if (args[k] !== undefined) patch[k] = args[k];
+      }
+      if (args.story !== undefined) patch.storyId = args.story;
+      if (args.why !== undefined) patch.complexityWhy = args.why;
+      const t = store.updateTicket(slug, args.ref, patch);
+      if (!t) throw new Error(`update: no ticket "${args.ref}" on ${meta.name}.`);
+      return { ok: true, project: slug, ticket: t };
+    },
+  },
+  {
+    name: 'claim',
+    description: 'Atomically claim a ticket before working it (moves it to doing). Fails if gone/done/claimed. by must be a UNIQUE per-worker id. Pass effort (the executor\'s baked level) to be refused if it doesn\'t match the derived tier. Never work a ticket whose claim did not return ok:true.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string' },
+        project: PROJECT_PROP,
+        by: { type: 'string', description: 'Unique per-worker id (e.g. claude-<8 hex>).' },
+        effort: { type: 'string', enum: store.VALID_EFFORTS },
+        force: { type: 'boolean', description: 'Steal a live claim — only when certain.' },
+        session: { type: 'string' },
+      },
+      required: ['ref', 'by'],
+    },
+    handler(args) {
+      const { slug } = resolveProject(args.project);
+      const by = requireBy(args, 'claim');
+      const drift = effortDrift(slug, args.ref, args.effort);
+      if (drift) return Object.assign({ ok: false, project: slug }, drift);
+      const res = store.claimTicket(slug, args.ref, by, { force: !!args.force, source: 'mcp', sessionId: sessionOf(args) });
+      return Object.assign({ project: slug }, res);
+    },
+  },
+  {
+    name: 'next',
+    description: 'Atomically claim the top-priority available ticket. model filters to one derived tier. Returns ok:false reason:empty when nothing is claimable.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project: PROJECT_PROP,
+        by: { type: 'string' },
+        model: { type: 'string', enum: store.VALID_MODELS },
+        priority: { type: 'string', enum: store.VALID_PRIORITY },
+        session: { type: 'string' },
+      },
+      required: ['by'],
+    },
+    handler(args) {
+      const { slug } = resolveProject(args.project);
+      const by = requireBy(args, 'next');
+      const res = store.claimNext(slug, by, { priority: args.priority, model: args.model, source: 'mcp', sessionId: sessionOf(args) });
+      return Object.assign({ project: slug }, res);
+    },
+  },
+  {
+    name: 'done',
+    description: 'Mark a claimed ticket done and release the claim. Stamp model + effort you actually ran as (provenance). by should match the claim.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string' },
+        project: PROJECT_PROP,
+        by: { type: 'string' },
+        model: { type: 'string', enum: store.VALID_MODELS },
+        effort: { type: 'string', enum: store.VALID_EFFORTS },
+        session: { type: 'string' },
+      },
+      required: ['ref', 'by'],
+    },
+    handler(args) {
+      const { slug } = resolveProject(args.project);
+      const by = requireBy(args, 'done');
+      const res = store.completeTicket(slug, args.ref, by, { source: 'mcp', model: args.model, effort: args.effort, sessionId: sessionOf(args) });
+      return Object.assign({ project: slug }, res);
+    },
+  },
+  {
+    name: 'release',
+    description: 'Drop a claim without finishing (optionally set status, e.g. back to todo). by should match the claim.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string' },
+        project: PROJECT_PROP,
+        by: { type: 'string' },
+        status: { type: 'string', enum: store.VALID_STATUS },
+        session: { type: 'string' },
+      },
+      required: ['ref', 'by'],
+    },
+    handler(args) {
+      const { slug } = resolveProject(args.project);
+      const by = requireBy(args, 'release');
+      const res = store.releaseTicket(slug, args.ref, by, { status: args.status, source: 'mcp', sessionId: sessionOf(args) });
+      return Object.assign({ project: slug }, res);
+    },
+  },
+  {
+    name: 'comment',
+    description: 'Add a note-to-self comment to a ticket (a progress note, decision, or spike finding). Does NOT pause — use ask for a question that needs the human.',
+    inputSchema: {
+      type: 'object',
+      properties: { ref: { type: 'string' }, project: PROJECT_PROP, body: { type: 'string' }, by: { type: 'string' } },
+      required: ['ref', 'body'],
+    },
+    handler(args) {
+      const { slug } = resolveProject(args.project);
+      const res = store.addComment(slug, args.ref, { body: args.body, by: args.by || 'agent', kind: 'comment', source: 'mcp' });
+      return Object.assign({ project: slug }, res);
+    },
+  },
+  {
+    name: 'ask',
+    description: 'Post a QUESTION to the human on a ticket — this means pause and wait for their dashboard reply, do not guess and continue. Poll comments for a source:"dashboard" reply.',
+    inputSchema: {
+      type: 'object',
+      properties: { ref: { type: 'string' }, project: PROJECT_PROP, body: { type: 'string' }, by: { type: 'string' } },
+      required: ['ref', 'body'],
+    },
+    handler(args) {
+      const { slug } = resolveProject(args.project);
+      const res = store.addComment(slug, args.ref, { body: args.body, by: args.by || 'agent', kind: 'question', source: 'mcp' });
+      return Object.assign({ project: slug }, res);
+    },
+  },
+  {
+    name: 'comments',
+    description: 'Read a ticket\'s full comment thread (read it BEFORE working the ticket — a prior agent may have left the context you need).',
+    inputSchema: {
+      type: 'object',
+      properties: { ref: { type: 'string' }, project: PROJECT_PROP },
+      required: ['ref'],
+    },
+    handler(args) {
+      const { slug } = resolveProject(args.project);
+      const t = store.getTicket(slug, args.ref);
+      if (!t) throw new Error(`comments: no ticket "${args.ref}".`);
+      return { project: slug, ref: t.ref, comments: t.comments || [], needsResponse: store.needsResponse(t) };
+    },
+  },
+  {
+    name: 'link',
+    description: 'Relate two tickets (the inverse is written automatically). verb: blocks | depends-on | related. A ticket blocked by an unfinished one is skipped by ready/next.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        from: { type: 'string' },
+        verb: { type: 'string', enum: ['blocks', 'depends-on', 'related'] },
+        to: { type: 'string' },
+        project: PROJECT_PROP,
+      },
+      required: ['from', 'verb', 'to'],
+    },
+    handler(args) {
+      const { slug } = resolveProject(args.project);
+      const res = store.linkTickets(slug, args.from, args.verb, args.to);
+      if (!res.ok) throw new Error(`link: ${res.reason}`);
+      return Object.assign({ project: slug }, res);
+    },
+  },
+  {
+    name: 'unlink',
+    description: 'Remove every link between two tickets (both directions).',
+    inputSchema: {
+      type: 'object',
+      properties: { a: { type: 'string' }, b: { type: 'string' }, project: PROJECT_PROP },
+      required: ['a', 'b'],
+    },
+    handler(args) {
+      const { slug } = resolveProject(args.project);
+      const res = store.unlinkTickets(slug, args.a, args.b);
+      if (!res.ok) throw new Error(`unlink: ${res.reason}`);
+      return Object.assign({ project: slug }, res);
+    },
+  },
+  {
+    name: 'assign',
+    description: 'Set a ticket\'s persistent assignee (defaults to "you", the human) — separate from an agent claim. Pass to:"none" or use unassign to clear.',
+    inputSchema: {
+      type: 'object',
+      properties: { ref: { type: 'string' }, to: { type: 'string' }, project: PROJECT_PROP },
+      required: ['ref'],
+    },
+    handler(args) {
+      const { slug } = resolveProject(args.project);
+      const who = args.to == null ? 'you' : (String(args.to).toLowerCase() === 'none' ? null : args.to);
+      const res = store.assignTicket(slug, args.ref, who, { source: 'mcp' });
+      if (!res.ok) throw new Error(`assign: no ticket "${args.ref}".`);
+      return Object.assign({ project: slug }, res);
+    },
+  },
+  {
+    name: 'models',
+    description: 'The live routing ladder: which complexity score maps to which model·effort right now, plus the enabled tiers/efforts, the routing master switch, and the bias.',
+    inputSchema: { type: 'object', properties: { project: PROJECT_PROP } },
+    handler() {
+      const prefs = store.getModelPrefs();
+      return { prefs, ladder: store.routingLadder(prefs) };
+    },
+  },
+  {
+    name: 'projects',
+    description: 'Every registered board with open/doing/done counts — the switcher across all projects.',
+    inputSchema: { type: 'object', properties: {} },
+    handler() {
+      return { projects: store.listProjects() };
+    },
+  },
+];
+
+const TOOL_BY_NAME = new Map(TOOLS.map((t) => [t.name, t]));
+
+function toolDescriptors() {
+  return TOOLS.map((t) => ({ name: t.name, description: t.description, inputSchema: t.inputSchema }));
+}
+
+/* ------------------------------------------------------------------ *
+ *  JSON-RPC request handling
+ *
+ *  handleRequest(msg) -> a response object to write back, or null for a
+ *  notification (no id) that takes no reply. Never throws: a tool error is
+ *  returned as an isError tool result the model can read; a protocol error is a
+ *  JSON-RPC error object.
+ * ------------------------------------------------------------------ */
+
+function rpcResult(id, result) {
+  return { jsonrpc: '2.0', id, result };
+}
+function rpcError(id, code, message) {
+  return { jsonrpc: '2.0', id, error: { code, message } };
+}
+
+function handleRequest(msg) {
+  if (!msg || msg.jsonrpc !== '2.0') return null;
+  const { id, method, params } = msg;
+  const isNotification = id === undefined || id === null;
+
+  if (method === 'initialize') {
+    const requested = params && params.protocolVersion;
+    return rpcResult(id, {
+      protocolVersion: requested || DEFAULT_PROTOCOL_VERSION,
+      capabilities: { tools: { listChanged: false } },
+      serverInfo: { name: SERVER_NAME, version: serverVersion() },
+    });
+  }
+
+  // Notifications carry no id and expect no response.
+  if (method === 'notifications/initialized' || (method && method.indexOf('notifications/') === 0)) {
+    return null;
+  }
+  if (method === 'ping') return rpcResult(id, {});
+
+  if (method === 'tools/list') {
+    return rpcResult(id, { tools: toolDescriptors() });
+  }
+
+  if (method === 'tools/call') {
+    const name = params && params.name;
+    const args = (params && params.arguments) || {};
+    const tool = TOOL_BY_NAME.get(name);
+    if (!tool) {
+      return rpcResult(id, { content: [{ type: 'text', text: `Unknown tool "${name}".` }], isError: true });
+    }
+    try {
+      const out = tool.handler(args);
+      return rpcResult(id, { content: [{ type: 'text', text: JSON.stringify(out, null, 2) }] });
+    } catch (e) {
+      return rpcResult(id, { content: [{ type: 'text', text: `${(e && e.message) || e}` }], isError: true });
+    }
+  }
+
+  if (isNotification) return null; // unknown notification: ignore
+  return rpcError(id, -32601, `Method not found: ${method}`);
+}
+
+module.exports = {
+  SERVER_NAME,
+  DEFAULT_PROTOCOL_VERSION,
+  TOOLS,
+  toolDescriptors,
+  resolveProject,
+  handleRequest,
+  serverVersion,
+};

--- a/plugins/sidequest/lib/mcp.js
+++ b/plugins/sidequest/lib/mcp.js
@@ -121,35 +121,37 @@ const PROJECT_PROP = { type: 'string', description: 'Board to target (a register
 const TOOLS = [
   {
     name: 'list',
-    description: 'List tickets on a board, grouped data for the caller to read. Add status to filter one column; archived:true shows archived tickets.',
+    description: 'List tickets on a board. status filters one column; archived:true shows archived. brief:true returns the compact shape (no bodies or threads) — default to it for routine orchestration reads.',
     inputSchema: {
       type: 'object',
       properties: {
         project: PROJECT_PROP,
         status: { type: 'string', enum: ['todo', 'doing', 'done'] },
         archived: { type: 'boolean' },
+        brief: { type: 'boolean', description: 'Compact tickets: ref/title/status/priority/complexity/model/effort/files/claim/blockedBy, plus a comments count and awaitingReply. No bodies.' },
       },
     },
     handler(args) {
       const { slug, meta } = resolveProject(args.project);
-      let tickets = store.listTickets(slug);
-      tickets = args.archived ? tickets.filter((t) => t.archived) : tickets.filter((t) => !t.archived);
-      if (args.status) tickets = tickets.filter((t) => t.status === String(args.status).toLowerCase());
-      return { project: slug, projectName: meta.name, tickets };
+      const payload = store.listPayload(slug, { status: args.status, archived: args.archived, brief: args.brief });
+      return Object.assign({ project: slug, projectName: meta.name }, payload);
     },
   },
   {
     name: 'ready',
-    description: 'The fan-out set: unclaimed, unblocked, not-done tickets, partitioned into parallel-safe waves by declared file scope. Spawn one executor per ticket in wave 1. model filters to one derived tier.',
+    description: 'The workable set: unclaimed, unblocked, not-done tickets, partitioned into parallel-safe waves by declared file scope. waves is always arrays of refs; full/compact tickets ride in tickets. model filters to one derived tier. brief:true returns compact tickets — default to it for orchestration reads.',
     inputSchema: {
       type: 'object',
-      properties: { project: PROJECT_PROP, model: { type: 'string', enum: store.VALID_MODELS } },
+      properties: {
+        project: PROJECT_PROP,
+        model: { type: 'string', enum: store.VALID_MODELS },
+        brief: { type: 'boolean', description: 'Compact tickets: ref/title/status/priority/complexity/model/effort/files/claim/blockedBy, plus a comments count and awaitingReply. No bodies.' },
+      },
     },
     handler(args) {
       const { slug, meta } = resolveProject(args.project);
-      const waves = store.readyWaves(slug, { model: args.model });
-      const tickets = store.readyTickets(slug, { model: args.model });
-      return { project: slug, projectName: meta.name, waves, tickets };
+      const payload = store.readyPayload(slug, { model: args.model, brief: args.brief });
+      return Object.assign({ project: slug, projectName: meta.name }, payload);
     },
   },
   {

--- a/plugins/sidequest/lib/store.js
+++ b/plugins/sidequest/lib/store.js
@@ -1247,6 +1247,9 @@ function claimTicket(slug, idOrRef, by, opts) {
     t.lastEventSource = opts.source ? String(opts.source) : 'cli';
     t.updatedAt = new Date().toISOString();
     writeJson(ticketFile(slug, t.id), t);
+    // Tie this claim to the worker's session so a SessionEnd/SubagentStop hook can
+    // release it immediately instead of waiting out the TTL. No-op without a session id.
+    if (opts.sessionId) registerWorker(opts.sessionId, slug, t.id, by);
     queueEventNotification(slug, t, t.lastEventType, t.lastEventSource);
     return { ok: true, ticket: t };
   });
@@ -1262,6 +1265,15 @@ function releaseTicket(slug, idOrRef, by, opts) {
   return withTicketLock(slug, found.id, () => {
     const t = getTicket(slug, found.id);
     if (!t) return { ok: false, reason: 'not_found' };
+    // A ticket that finished is done — never yanked back to another status by a
+    // release racing behind it. This closes a TOCTOU window: a caller (notably
+    // reconcileSession, which pre-checks status on an unlocked read taken before
+    // it could get this lock) can be scheduled between a completeTicket() clearing
+    // the claim and this fresh read; without this guard, the empty claim would
+    // vacuously pass the ownership check below and opts.status would stomp the
+    // ticket straight back to "todo", silently un-completing finished work.
+    // Mirrors claimTicket's own "done" refusal just above.
+    if (t.status === 'done' && !opts.force) return { ok: false, reason: 'done', ticket: t };
     const held = t.claim;
     if (held && held.by && held.by !== by && !isClaimStale(held) && !opts.force) {
       return { ok: false, reason: 'not_owner', ticket: t, claim: held };
@@ -1273,6 +1285,10 @@ function releaseTicket(slug, idOrRef, by, opts) {
     t.lastEventSource = opts.source ? String(opts.source) : 'cli';
     t.updatedAt = new Date().toISOString();
     writeJson(ticketFile(slug, t.id), t);
+    // Drop this claim from the session registry — it's no longer outstanding, so a
+    // later reconcile of the same session won't try to touch it (keyed on the
+    // ticket, so a blank `by` on the done doesn't matter). No-op without a session id.
+    if (opts.sessionId) unregisterClaim(opts.sessionId, slug, t.id);
     queueEventNotification(slug, t, t.lastEventType, t.lastEventSource);
     return { ok: true, ticket: t };
   });
@@ -1364,7 +1380,7 @@ function claimNext(slug, by, opts) {
       return String(a.createdAt).localeCompare(String(b.createdAt));
     });
   for (const cand of candidates) {
-    const res = claimTicket(slug, cand.id, by, { source: opts.source });
+    const res = claimTicket(slug, cand.id, by, { source: opts.source, sessionId: opts.sessionId });
     if (res.ok) return res;
     // Lost the race or it changed under us — try the next candidate.
   }
@@ -2140,6 +2156,169 @@ function fireDueReminders() {
 }
 
 /* ------------------------------------------------------------------ *
+ *  Worker registry (session -> the claims it holds)
+ *
+ *  The claim TTL (default 60 min) is the backstop that frees a crashed worker's
+ *  ticket. But when a *session* ends cleanly, we know its claims are dead right
+ *  then — no reason to make a dependent wait out the TTL. The SessionEnd hook
+ *  fires on that boundary; it has the session id but a claim is tagged
+ *  only with an opaque `--by`. This tiny registry is the missing link: it maps a
+ *  session id to the claims taken under it, so reconcileSession() can release
+ *  exactly those (and only those — never another live session's) on the spot.
+ *
+ *  One file, projects/workers.json, a sibling to notifications.json:
+ *    { sessions: { <sessionId>: { updatedAt, claims: [{ slug, ticketId, by, at }] } } }
+ *
+ *  Fail-soft throughout: a missing/garbage file degrades to an empty registry,
+ *  and any hiccup here must never break a claim (the TTL still covers us). The
+ *  registry is an OPTIMIZATION over the TTL, not a new source of truth — nothing
+ *  reads it to decide whether a claim is valid, only to speed up releasing it.
+ * ------------------------------------------------------------------ */
+
+// Sessions untouched for this long with no live claims are pruned on write, so
+// the file can't grow forever from sessions that ended without a reconcile hook.
+const WORKER_SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+function workersFile() {
+  return path.join(projectsRoot(), 'workers.json');
+}
+function workersLockPath() {
+  return path.join(projectsRoot(), '.workers.lock');
+}
+function readWorkers() {
+  const d = readJson(workersFile(), null);
+  return d && typeof d === 'object' && d.sessions && typeof d.sessions === 'object' ? d : { sessions: {} };
+}
+function writeWorkers(obj) {
+  writeJson(workersFile(), obj);
+}
+function withWorkersLock(fn) {
+  const lock = workersLockPath();
+  const locked = acquireLock(lock);
+  try {
+    return fn();
+  } finally {
+    if (locked) releaseLock(lock);
+  }
+}
+
+// Drop sessions with no claims left, and any whose last activity is older than
+// the TTL (a session that ended without its reconcile hook ever firing). Mutates
+// and returns the registry object.
+function pruneWorkers(w) {
+  const cutoff = Date.now() - WORKER_SESSION_TTL_MS;
+  for (const sid of Object.keys(w.sessions)) {
+    const s = w.sessions[sid];
+    const claims = s && Array.isArray(s.claims) ? s.claims : [];
+    const ts = s && s.updatedAt ? Date.parse(s.updatedAt) : NaN;
+    if (!claims.length || (Number.isFinite(ts) && ts < cutoff)) delete w.sessions[sid];
+  }
+  return w;
+}
+
+// Record that `sessionId` now holds a claim on (slug, ticketId) under worker id
+// `by`. Idempotent per (slug, ticketId). No-op without a session id — the whole
+// feature is dormant (and the TTL covers everything) until an id starts flowing.
+function registerWorker(sessionId, slug, ticketId, by) {
+  if (!sessionId || !slug || !ticketId) return;
+  try {
+    withWorkersLock(() => {
+      const w = readWorkers();
+      const now = new Date().toISOString();
+      const s = w.sessions[sessionId] || (w.sessions[sessionId] = { updatedAt: now, claims: [] });
+      s.updatedAt = now;
+      if (!Array.isArray(s.claims)) s.claims = [];
+      if (!s.claims.some((c) => c.slug === slug && c.ticketId === ticketId)) {
+        s.claims.push({ slug, ticketId, by: by || null, at: now });
+      }
+      writeWorkers(pruneWorkers(w));
+    });
+  } catch (_) {
+    /* the TTL is the backstop — a registry write failure must never break a claim */
+  }
+}
+
+// Forget a claim (the worker finished or dropped it). No-op without a session id.
+function unregisterClaim(sessionId, slug, ticketId) {
+  if (!sessionId || !slug || !ticketId) return;
+  try {
+    withWorkersLock(() => {
+      const w = readWorkers();
+      const s = w.sessions[sessionId];
+      if (!s || !Array.isArray(s.claims)) return;
+      s.claims = s.claims.filter((c) => !(c.slug === slug && c.ticketId === ticketId));
+      s.updatedAt = new Date().toISOString();
+      writeWorkers(pruneWorkers(w));
+    });
+  } catch (_) {
+    /* best effort */
+  }
+}
+
+// Release every claim registered to `sessionId` that is still genuinely held by
+// that session's worker and not finished — moving each ticket back to `todo` and
+// leaving a note. This is what the SessionEnd hook calls. Safe by construction:
+// it only touches tickets the registry attributes to THIS session,
+// and skips any that were completed or re-claimed by someone else in the interim.
+// Idempotent — the session's registry entry is cleared as part of the pass, so a
+// second call finds nothing. Returns { ok, released: [ref...] }.
+function reconcileSession(sessionId, opts) {
+  opts = opts || {};
+  const reason = opts.reason ? String(opts.reason) : 'worker session ended';
+  const source = opts.source ? String(opts.source) : 'cli';
+  const released = [];
+  if (!sessionId) return { ok: true, released };
+
+  // Snapshot this session's claims and clear its registry entry in one locked
+  // step, so a concurrent reconcile of the same session can't double-release.
+  let claims = [];
+  try {
+    withWorkersLock(() => {
+      const w = readWorkers();
+      const s = w.sessions[sessionId];
+      claims = s && Array.isArray(s.claims) ? s.claims.slice() : [];
+      if (s) {
+        delete w.sessions[sessionId];
+        writeWorkers(w);
+      }
+    });
+  } catch (_) {
+    return { ok: true, released };
+  }
+
+  for (const c of claims) {
+    let t;
+    try {
+      t = getTicket(c.slug, c.ticketId);
+    } catch (_) {
+      continue;
+    }
+    if (!t || t.archived || t.status === 'done') continue; // finished work is left alone
+    if (!t.claim || !t.claim.by) continue; // already released
+    if (c.by && t.claim.by !== c.by) continue; // re-claimed by someone else since — not ours to touch
+    try {
+      const res = releaseTicket(c.slug, c.ticketId, t.claim.by, { status: 'todo', source });
+      if (res && res.ok) {
+        released.push(t.ref);
+        try {
+          addComment(c.slug, c.ticketId, {
+            by: 'sidequest',
+            kind: 'comment',
+            source,
+            body: `↩️ Auto-released to **todo**: ${reason} (was claimed by \`${t.claim.by}\`). It's back in the ready pool for another worker.`,
+          });
+        } catch (_) {
+          /* the release is what matters; the note is a courtesy */
+        }
+      }
+    } catch (_) {
+      /* one bad ticket must not abort the rest of the reconcile */
+    }
+  }
+  return { ok: true, released };
+}
+
+/* ------------------------------------------------------------------ *
  *  Server lockfile (used by CLI + server to find/reuse a running dashboard)
  * ------------------------------------------------------------------ */
 
@@ -2235,4 +2414,7 @@ module.exports = {
   readServerInfo,
   writeServerInfo,
   clearServerInfo,
+  registerWorker,
+  unregisterClaim,
+  reconcileSession,
 };

--- a/plugins/sidequest/lib/store.js
+++ b/plugins/sidequest/lib/store.js
@@ -1700,6 +1700,80 @@ function isBlocked(slug, ticket) {
   return openBlockers(slug, ticket).length > 0;
 }
 
+// Resolve a ticket's open blockers against an in-memory ref->ticket index
+// (uppercased refs), instead of openBlockers()'s per-link getTicket fallback:
+// links store "SQ-n" refs while ticket files are named by id, so the per-link
+// path degenerates into a full-board rescan per link.
+function openBlockersFromIndex(index, ticket) {
+  if (!ticket || !Array.isArray(ticket.links)) return [];
+  const out = [];
+  for (const l of ticket.links) {
+    if (l.type !== 'blocked-by') continue;
+    const blocker = index.get(String(l.ref).toUpperCase());
+    if (blocker && blocker.status !== 'done') out.push(blocker.ref);
+  }
+  return out;
+}
+
+// A compact projection of a ticket for orchestration reads (`--brief` on the
+// CLI, `brief: true` over MCP): everything an orchestrator needs to route,
+// batch, and spawn, none of the bodies. A full ticket carries its whole
+// description and comment thread, which an orchestrator scanning a board pays
+// for on every read without needing; the executor working the ticket reads the
+// full record instead. opts.blockedBy short-circuits the blocker lookup when
+// the caller already knows it (the ready set is unblocked by construction);
+// opts.index resolves blockers in memory. Bare briefTicket(slug, t) still
+// works but pays the per-link scan.
+function briefTicket(slug, t, opts) {
+  opts = opts || {};
+  let blockedBy;
+  if (Array.isArray(opts.blockedBy)) blockedBy = opts.blockedBy;
+  else if (opts.index) blockedBy = openBlockersFromIndex(opts.index, t);
+  else blockedBy = openBlockers(slug, t);
+  return {
+    ref: t.ref,
+    title: t.title,
+    status: t.status,
+    priority: t.priority,
+    complexity: t.complexity || null,
+    model: t.model || null,
+    effort: t.effort || null,
+    files: Array.isArray(t.files) ? t.files : [],
+    claim: t.claim && t.claim.by ? { by: t.claim.by, at: t.claim.at, stale: isClaimStale(t.claim) } : null,
+    blockedBy,
+    comments: Array.isArray(t.comments) ? t.comments.length : 0,
+    awaitingReply: needsResponse(t),
+  };
+}
+
+// The one board-read payload both transports (CLI --json and MCP) serve, so
+// their shapes cannot drift: filtering, the brief projection, and the blocker
+// index live here and nowhere else.
+function listPayload(slug, opts) {
+  opts = opts || {};
+  const all = listTickets(slug);
+  let tickets = opts.archived ? all.filter((t) => t.archived) : all.filter((t) => !t.archived);
+  if (opts.status) tickets = tickets.filter((t) => t.status === String(opts.status).toLowerCase());
+  if (opts.brief) {
+    // Blockers may live outside the filtered set, so index the whole board.
+    const index = new Map(all.map((t) => [String(t.ref).toUpperCase(), t]));
+    tickets = tickets.map((t) => briefTicket(slug, t, { index }));
+  }
+  return { tickets };
+}
+
+// Same for the ready read. Waves are ALWAYS arrays of refs (both transports,
+// brief or not) — full tickets ride only in `tickets`, so nothing is
+// serialized twice and the field has one shape. Ready tickets are unblocked by
+// construction, so brief projections skip the blocker lookup outright.
+function readyPayload(slug, opts) {
+  opts = opts || {};
+  let tickets = readyTickets(slug, { model: opts.model });
+  const waves = readyWaves(slug, { model: opts.model }).map((wave) => wave.map((t) => t.ref));
+  if (opts.brief) tickets = tickets.map((t) => briefTicket(slug, t, { blockedBy: [] }));
+  return { tickets, waves };
+}
+
 /* ------------------------------------------------------------------ *
  *  Notifications
  *
@@ -2390,6 +2464,9 @@ module.exports = {
   unlinkTickets,
   openBlockers,
   isBlocked,
+  briefTicket,
+  listPayload,
+  readyPayload,
   archiveTicket,
   unarchiveTicket,
   archiveAllDone,

--- a/plugins/sidequest/lib/work.js
+++ b/plugins/sidequest/lib/work.js
@@ -1,0 +1,170 @@
+'use strict';
+/**
+ * sidequest - headless worker drainer (`sidequest work`)
+ *
+ * Turns the board from a fan-out tool you drive into a queue that works itself:
+ * read the ready set, and spawn one headless `claude -p` run per ready ticket at
+ * the ticket's derived model tier. Safe next to any interactive session because
+ * claiming stays atomic — a headless run that loses a claim race just no-ops.
+ *
+ * The planning half is pure and testable (planWork / --dry-run computes exactly
+ * what WOULD be spawned without launching anything); runWork() adds the actual
+ * child_process spawns on top. Node stdlib only.
+ *
+ * Effort note: reasoning effort is only settable via agent-definition frontmatter,
+ * which a headless `-p` run has no equivalent flag for — so a headless run carries
+ * the ticket's MODEL tier (via --model) but runs at that model's default effort.
+ * The claim still records the derived effort for provenance. This is why headless
+ * draining is the "unattended overflow" path, not a replacement for interactive
+ * fan-out through the effort-pinned sidequest-exec-* agents.
+ */
+
+const path = require('path');
+const crypto = require('crypto');
+const { spawn, spawnSync } = require('child_process');
+const store = require('./store');
+
+const CLI_PATH = path.join(__dirname, '..', 'bin', 'sidequest.js');
+const DEFAULT_MAX = 3;      // headless runs per wave
+const DEFAULT_MAX_WAVES = 5; // safety cap on how many waves one drain will chew through
+
+// Cap a ticket's derived tier to the tiers that actually exist to spawn. `fable`
+// isn't a spawnable CLI model alias, so treat opus as the ceiling for headless.
+const SPAWNABLE = new Set(['opus', 'sonnet', 'haiku']);
+function capTier(model) {
+  if (SPAWNABLE.has(model)) return model;
+  if (model === 'fable') return 'opus'; // fable derivations run headless as opus
+  return 'sonnet';
+}
+
+// Is the `claude` CLI present to spawn? A headless drain is pointless without it,
+// and we'd rather say so than hang. shell:true so a Windows `claude.cmd` shim on
+// PATH is found (a bare spawn misses `.cmd`/`.ps1` launchers).
+function claudeAvailable() {
+  try {
+    const r = spawnSync('claude', ['--version'], { encoding: 'utf8', timeout: 10000, shell: true });
+    return r.status === 0 || (r.stdout && /\d+\.\d+/.test(r.stdout));
+  } catch (_) {
+    return false;
+  }
+}
+
+function worker(ref) {
+  return `headless-${String(ref).toLowerCase()}-${crypto.randomBytes(3).toString('hex')}`;
+}
+
+// The one-ticket executor brief handed to a headless run. Mirrors the
+// sidequest-exec-* protocol: claim -> read -> do -> verify -> done/release.
+function executorPrompt(ref, by, tier, effort, projectPath) {
+  const cli = `node "${CLI_PATH}"`;
+  const proj = `--project "${projectPath}"`;
+  const eff = effort ? ` --effort ${effort}` : '';
+  return [
+    `You are a headless sidequest executor. Work EXACTLY ONE ticket: ${ref}. Do nothing outside its scope.`,
+    '',
+    `1. CLAIM FIRST: ${cli} claim ${ref} --by ${by}${eff} ${proj}`,
+    `   If the claim fails for ANY reason (already claimed / done / gone, or an effort mismatch), STOP immediately and report it verbatim — do NOT touch any file.`,
+    `2. READ IN: ${cli} list --json ${proj} (find ${ref}) and ${cli} comments ${ref} ${proj}. A prior agent may have left the context you need.`,
+    `3. DO the ticket's work — only what it specifies. Verify it the way the ticket says (run its test / syntax check / reproduction) before declaring success.`,
+    `4. If it was an investigation, write findings back: ${cli} comment ${ref} -m "..." ${proj}.`,
+    `5. CLOSE: ${cli} done ${ref} --by ${by} --model ${tier}${eff} ${proj}`,
+    `   If you could not finish: ${cli} release ${ref} --by ${by} --status todo ${proj} and say why.`,
+    '',
+    `Report concisely: claim result, what changed, verification output, close confirmation.`,
+  ].join('\n');
+}
+
+// Build the spawn plan for the next batch of ready work WITHOUT launching
+// anything. Returns { waves, plan: [{ ref, tier, effort, by, argv, cwd }] } for
+// the first wave (capped at max). Pure — the --dry-run path and the tests use it.
+function planWork(slug, opts) {
+  opts = opts || {};
+  const meta = store.readMeta(slug) || {};
+  const projectPath = meta.path || process.cwd();
+  const max = Number.isFinite(Number(opts.max)) && Number(opts.max) > 0 ? Number(opts.max) : DEFAULT_MAX;
+  const waves = store.readyWaves(slug, { model: opts.model });
+  const wave = waves[0] || [];
+  const batch = wave.slice(0, max);
+  const permFlags = permissionArgs(opts);
+  const plan = batch.map((t) => {
+    const tier = capTier(t.model);
+    const by = worker(t.ref);
+    // The executor brief goes over STDIN, not argv — it's a large multi-line
+    // string, and keeping it out of the command line is what makes the spawn
+    // survive `shell: true` on Windows (needed to find claude.cmd) without any
+    // quote/newline escaping. So argv is just the small, safe flag set.
+    const prompt = executorPrompt(t.ref, by, tier, t.effort, projectPath);
+    const argv = ['-p', '--model', tier, '--output-format', 'json'].concat(permFlags);
+    return { ref: t.ref, tier, effort: t.effort || null, by, prompt, argv, cwd: projectPath };
+  });
+  return { waves, waveCount: waves.length, plan, dropped: Math.max(0, wave.length - batch.length) };
+}
+
+// The permission posture for the spawned runs. A drain is unattended, so the
+// default lets it edit and run its own board commands; the user can harden or
+// loosen it. `--yolo` is the escape hatch for a fully non-interactive run.
+function permissionArgs(opts) {
+  if (opts.yolo) return ['--dangerously-skip-permissions'];
+  if (opts.permissionMode) return ['--permission-mode', String(opts.permissionMode)];
+  return ['--permission-mode', 'acceptEdits'];
+}
+
+// Spawn one headless run, resolving to a result record. Never rejects — a spawn
+// failure resolves to an error result so one bad child can't sink the batch.
+function spawnOne(item) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      // shell:true finds a Windows claude.cmd shim; the prompt rides on stdin so
+      // no giant multi-line arg ever hits the shell.
+      child = spawn('claude', item.argv, { cwd: item.cwd, shell: true });
+    } catch (e) {
+      resolve({ ref: item.ref, ok: false, error: (e && e.message) || String(e) });
+      return;
+    }
+    let out = '';
+    let err = '';
+    if (child.stdout) child.stdout.on('data', (d) => (out += d));
+    if (child.stderr) child.stderr.on('data', (d) => (err += d));
+    child.on('error', (e) => resolve({ ref: item.ref, ok: false, error: (e && e.message) || String(e) }));
+    child.on('close', (code) => {
+      resolve({ ref: item.ref, ok: code === 0, code, stdout: out.slice(-4000), stderr: err.slice(-2000) });
+    });
+    // Hand the executor brief to the headless run over stdin, then close it.
+    try {
+      if (child.stdin) {
+        child.stdin.write(item.prompt || '');
+        child.stdin.end();
+      }
+    } catch (_) {
+      /* if stdin already closed, the child.on('error') path reports it */
+    }
+  });
+}
+
+// Drain the ready set by spawning headless runs, wave by wave, until the board
+// is clear or the wave cap is hit. Re-reads `ready` between waves so tickets a
+// finished wave unblocks get picked up. Returns a summary.
+async function runWork(slug, opts, log) {
+  opts = opts || {};
+  log = log || (() => {});
+  if (!claudeAvailable()) {
+    return { ok: false, reason: 'no_claude', message: 'the `claude` CLI is not on PATH — cannot spawn headless runs.' };
+  }
+  const maxWaves = Number.isFinite(Number(opts.maxWaves)) && Number(opts.maxWaves) > 0 ? Number(opts.maxWaves) : DEFAULT_MAX_WAVES;
+  const results = [];
+  let wavesRun = 0;
+  for (let w = 0; w < (opts.singleWave ? 1 : maxWaves); w++) {
+    const { plan } = planWork(slug, opts);
+    if (!plan.length) break;
+    wavesRun++;
+    log(`wave ${wavesRun}: launching ${plan.length} headless run(s) — ${plan.map((p) => `${p.ref}·${p.tier}`).join(', ')}`);
+    const waveResults = await Promise.all(plan.map(spawnOne));
+    results.push(...waveResults);
+    // If nothing in this wave actually completed, stop rather than spin.
+    if (!waveResults.some((r) => r.ok)) break;
+  }
+  return { ok: true, wavesRun, results };
+}
+
+module.exports = { planWork, runWork, capTier, claudeAvailable, executorPrompt, CLI_PATH };

--- a/plugins/sidequest/scripts/_exec-template.md
+++ b/plugins/sidequest/scripts/_exec-template.md
@@ -1,56 +1,59 @@
 ---
 name: sidequest-exec-{{EFFORT}}
 description: >-
-  Executes one sidequest ticket at {{EFFORT}} reasoning effort. Spawn with a unique lowercase-hyphen
-  name (e.g. sidequest-exec-{{EFFORT}}-<ticket>) and the ticket's model (never haiku); pass the ticket
-  ref, the sidequest CLI command, a unique --by id, and the concrete task. Claims first, does exactly
-  that work, verifies, marks it done. See the sidequest skill for routing and fan-out doctrine.
+  Executes one or more sidequest tickets at {{EFFORT}} reasoning effort. Spawn with a unique
+  lowercase-hyphen name and the tickets' model; pass the ref(s) — all stamped {{EFFORT}} — the
+  sidequest command, a unique --by id, and the task(s). Claims each first, works it, verifies, dones.
 effort: {{EFFORT}}
 ---
 
-You are a sidequest ticket executor running at **{{EFFORT}}** reasoning effort.
+You are a sidequest ticket executor running at **{{EFFORT}}** reasoning effort. You may be handed ONE
+ticket ref or a LIST of refs (a batch of small same-tier tickets) — a batch is worked **one ticket at
+a time, in the order given**, running the full protocol per ticket.
+
+**Your run is SHORT and BOUNDED — you are one leg of an orchestrator↔executor loop, not a session.**
+Do the ticket's work, verify it the named way, report, end. Do not re-explore the codebase beyond the
+ticket's stated files, re-verify things the ticket didn't ask about, or widen scope "while you're
+here". The moment the work turns out bigger or murkier than the ticket describes, STOP and bounce it
+back (release + a findings comment saying what you hit) — the orchestrator re-scopes faster than you
+can wander. A fast bounce-back is a success, not a failure.
 
 **Where things live — never scan the filesystem from root (`find /` etc.) to locate any of these:**
-- CLI: `plugins/sidequest/bin/sidequest.js` (invoke via `node "<path>/bin/sidequest.js"`, given to you as
-  the `sidequest` command prefix).
-- Data: central store, default `~/.claude/sidequest` (override: `SIDEQUEST_HOME` env var) —
-  `projects/<slug>/tickets/<id>.json` per ticket.
-- Ticket attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that same root. Get
-  the slug/id/filenames from `sidequest list --json`, then join the path — don't hunt for the file.
+- CLI: `plugins/sidequest/bin/sidequest.js` (given to you as the `sidequest` command prefix).
+- Data: central store, default `~/.claude/sidequest` (override: `SIDEQUEST_HOME` env var).
+- Attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that root — get slug/id/
+  filenames from `sidequest list --json`, then join the path.
 
-Protocol, in order:
-1. **Claim first**: run `sidequest claim <ref> --by <worker-id> --effort {{EFFORT}} --project <project>`
-   (add `--effort {{EFFORT}}` even if the command you were handed omits it). That flag lets the board
-   verify you're the right-tier executor: it refuses the claim if the ticket's derived effort isn't
-   `{{EFFORT}}` — i.e. the orchestrator spawned the wrong `sidequest-exec-<effort>`. If the claim FAILS
-   for ANY reason (already claimed / done / gone, or an effort mismatch), STOP immediately and report the
-   failure verbatim — do not touch any file. On an effort mismatch the failure names the executor to
-   spawn instead, so the orchestrator can re-route.
-2. **Read yourself in**: read the ticket's description AND its comment thread
-   (`sidequest comments <ref> --project <project>`), plus any linked tickets' threads. A prior or
-   parallel agent may have already mapped the code or left the context you need — don't rediscover it.
-3. **Do exactly the ticket's work** — nothing beyond its scope. No drive-by fixes; if you notice a
-   separate issue, mention it in your report instead of fixing it.
-4. **Verify** your change the way the ticket (or the orchestrator's prompt) specifies — run the
-   syntax check, test, or reproduction it names before declaring success.
-5. **Record findings as a comment**: when the ticket was an investigation/spike, or you learned
-   anything that matters later, write it back with
-   `sidequest comment <ref> -m "..." --project <project>` — root cause with evidence (`file:line`),
-   what you ruled out, the fix, and how you verified. This durable comment (not your orchestrator
-   report) is the deliverable of an investigation. Markdown, real newlines — never a literal `\n`.
-6. **Close**: `sidequest done <ref> --by <same-worker-id> --model <your tier> --effort {{EFFORT}} --project <project>`
-   — stamp the tier you actually ran as. If you could not finish, `sidequest release <ref> --by
-   <same-worker-id> --status todo` and say why.
+Protocol, per ticket, in order:
+1. **Claim first**: `sidequest claim <ref> --by <worker-id> --effort {{EFFORT}} --project <project>`
+   (add `--effort {{EFFORT}}` even if the command you were handed omits it — the board refuses the
+   claim if the ticket's derived effort isn't `{{EFFORT}}`, i.e. the orchestrator spawned the wrong
+   executor). If the claim FAILS for ANY reason (already claimed / done / gone / effort mismatch), do
+   NOT touch any file for that ticket — in a batch, report the failure and move to the next ref;
+   for a single ticket, stop and report the failure verbatim. On an effort mismatch the failure names
+   the executor to spawn instead, so the orchestrator can re-route.
+2. **Read yourself in**: the ticket's description AND its comment thread
+   (`sidequest comments <ref> --project <project>`), plus any linked tickets' threads — a prior agent
+   may have left the context you need; don't rediscover it. (Skip the thread reads when the
+   orchestrator told you the ticket has no comments — don't fetch empty threads.)
+3. **Do exactly the ticket's work** — nothing beyond its scope. No drive-by fixes; a separate issue
+   you notice goes in your report, not in the diff.
+4. **Verify** the way the ticket (or the orchestrator's prompt) specifies — run the named check/test/
+   reproduction before declaring success.
+5. **Record findings as a comment** when the ticket was an investigation/spike or you learned
+   something that matters later: `sidequest comment <ref> -m "..." --project <project>` — root cause
+   with evidence (`file:line`), what you ruled out, the fix, how you verified. For an investigation
+   this comment (not your report) is the deliverable. Markdown, real newlines — never a literal `\n`.
+6. **Close**: `sidequest done <ref> --by <same-worker-id> --model <your tier> --effort {{EFFORT}}
+   --project <project>`. Couldn't finish? `sidequest release <ref> --by <same-worker-id> --status
+   todo` and say why. In a batch, then move to the next ref.
 
-**Stuck? Escalate before you thrash.** If the ticket turns out harder or murkier than your tier can
-handle, or two honest attempts haven't moved it, and you have an `advisor` tool available, call it. It
-forwards your full context to a stronger reviewer model, which is a genuine escalation for a low or
-mid-tier executor: you can reach a stronger model this way even when the orchestrator that spawned you
-(often already top-tier) can't use advisor at all. Reach for it when the work is genuinely difficult or
-unclear, before you guess or release. It's an escape hatch, not a routine step, so don't call it on work
-your tier can handle. No `advisor` tool in this environment? Then leave a findings comment and
-`sidequest release <ref> --by <same-worker-id> --status todo` so a higher tier can pick it up.
+**Stuck? Escalate before you thrash.** If a ticket is harder or murkier than your tier can handle, or
+two honest attempts haven't moved it, and an `advisor` tool is available, call it — it forwards your
+context to a stronger reviewer model (a genuine escalation even when your orchestrator can't use
+advisor). It's an escape hatch, not a routine step. No advisor? Leave a findings comment and
+`release --status todo` so a higher tier can pick it up.
 
-Report concretely: claim result, what changed (files/lines), verification output, close confirmation.
-Your final message is returned to the orchestrator — data, not conversation. It is a summary; the
-findings comment on the ticket is the record that persists.
+Report tersely, as data: per ticket — claim result, what changed (files/lines), verification output,
+close confirmation. Your final message returns to the orchestrator; the findings comment on the
+ticket is the record that persists.

--- a/plugins/sidequest/skills/sidequest/SKILL.md
+++ b/plugins/sidequest/skills/sidequest/SKILL.md
@@ -1,204 +1,132 @@
 ---
 name: sidequest
 description: >-
-  Open the sidequest board (a live, self-hosted Kanban of tickets) or manage tickets from the CLI.
+  Open the sidequest board (a live, self-hosted Kanban of tickets) or manage tickets from the CLI/MCP.
   Use for "show me the dashboard", "open the board/kanban", "what's on my board", or to file, list,
-  update, move, close, prioritize, label, or delete tickets — e.g. "add a bug ticket", "close
-  SQ-3", "bump SQ-5 to urgent". Use when the user wants to WORK the board — "grab the next task",
-  "pick up SQ-3" — which requires atomically CLAIMING a ticket first so shared boards stay safe
-  across agents. Use when the user hands you substantial or multi-part work — decompose it into
-  linked tickets BEFORE implementing, then work them one at a time. Use to comment on a ticket, ask
-  the user something on it, or await a reply — a question means pause-and-wait, unlike a plain
-  note-to-self comment. Use to relate tickets (depends-on/blocks). Tickets carry a complexity score
-  that drives model/effort routing. For a mid-task side issue, prefer the ticket-filer agent
-  instead of derailing.
+  update, move, close, prioritize, label, or delete tickets — e.g. "add a bug ticket", "close SQ-3",
+  "bump SQ-5 to urgent". Use when the user wants to WORK the board — "grab the next task", "pick up
+  SQ-3" — which requires atomically CLAIMING a ticket first so shared boards stay safe across agents.
+  Use when the user hands you substantial or multi-part work — decompose it into linked tickets BEFORE
+  implementing. Use to comment on a ticket, ask the user something on it (a question means
+  pause-and-wait), or relate tickets (depends-on/blocks). Tickets carry a complexity score that drives
+  model/effort routing. For a mid-task side issue, prefer the ticket-filer agent instead of derailing.
 ---
 
 # sidequest
 
+sidequest is a Trello-light quest log. Tickets live in a central store under `~/.claude/sidequest`
+(keyed by project path), and a bundled dashboard shows them as a live Kanban board — every project at
+once. Everything is driven by one CLI (`bin/sidequest.js`) or the matching MCP tools.
+
+Detail that used to live inline here is split into reference files — **read them only when the
+situation calls for it**:
+
+- [references/orchestration.md](references/orchestration.md) — fan-out waves, workflows (opt-in,
+  sizing), agent-teams caveats, spike tickets, unattended draining (`sidequest work`).
+- [references/routing-details.md](references/routing-details.md) — how the capability ladder is built,
+  bias, the effort grid, a worked routing example.
+- [references/external-trackers.md](references/external-trackers.md) — running sidequest alongside
+  Jira / Linear / GitHub Issues.
+- [references/board-features.md](references/board-features.md) — stories, notifications, reminders,
+  human assignment, attachment paths.
+
 ## Plan substantial work on the board first
 
 When the user gives you a task that is **more than a single small change** — a feature with several
-parts, a request with multiple deliverables, or an explicit "split this into tickets" / "make tickets
-for this" — do this **before writing any code**:
+parts, multiple deliverables, or an explicit "split this into tickets" — do this **before writing any
+code**:
 
-**Scout before you decompose — in parallel.** For anything non-trivial, build a quick map of the
-surface first, but fan a couple of read-only explorers out **at once** (one per subsystem or open
-question) instead of reading file-by-file yourself. That short parallel scout is exactly what lets you
-cut the work into pieces that are genuinely *independent* in the next step — guessing the boundaries
-without it produces tickets that collide. Keep it proportional: a small task needs no scout, a big one
-needs a few explorers, not twenty.
+0. **Decide the shape.** One cohesive change → a single ticket, done. A feature that naturally breaks
+   into several tickets sharing a goal → create a **story** first (`sidequest story add -t "..."`),
+   then file each piece into it with `--story US-n`. Infer this yourself; the user shouldn't have to
+   say "make a story". (Story commands: [references/board-features.md](references/board-features.md).)
+1. **Decompose into ATOMIC tickets** (`sidequest add ...`). One ticket = one concrete change — one
+   function, one file, one behavior — that its executor can finish **without discovering anything**.
+   The test: if completing the ticket would require investigation its description doesn't carry, it
+   isn't atomic yet — split it further, or investigate first yourself and put what you learned in the
+   spec. This is the top cause of stuck executors: a weaker model handed too much scope with too
+   little context. Cut along file/module boundaries (not conceptual halves), declare each piece's
+   scope with `--file` (repeatable; a dir prefix covers everything under it), and shrink until the
+   complexity drops — a piece still scoring 7+ is usually a small design ticket plus a mechanical
+   application ticket.
+2. **Link dependencies**: `sidequest link SQ-4 depends-on SQ-3`. Shape a story as design → wave(s) →
+   integrate, so `ready` naturally serializes the phases.
+3. **Execute proportionally** — see "Execute proportionally" below. The board stays the source of
+   truth for what's left.
 
-0. **First decide the shape: a user story, or a standalone ticket.** Judge the request:
-   - **Standalone ticket** — one cohesive change, a single bug, a small task. File one ticket
-     (`sidequest add ...`) and stop deciding; no story needed. Most requests are this.
-   - **User story** — a feature that naturally breaks into several tickets that share a goal (a "backend
-     + API + dashboard + docs" build, an epic, anything you'd otherwise decompose into many tickets).
-     Create a **story** first (`sidequest story add -t "..."`), then file each piece into it with
-     `sidequest add ... --story US-n`. The board color-codes every ticket by its story, so the whole
-     arc stays visually grouped. This is your call — the user shouldn't have to say "make a story";
-     infer it from the scope.
-1. **Decompose** the work into one ticket per distinct piece (`sidequest add ...`, adding `--story US-n`
-   when it belongs to a story from step 0). Cut along file boundaries, declare each piece's scope with
-   `--file`, and size pieces so a cheaper tier can execute them — see "Decompose for parallelism" below.
-2. **Link dependencies** so the order is explicit: `sidequest link SQ-4 depends-on SQ-3`,
-   `sidequest link SQ-2 blocks SQ-8`. (See "Link tickets" below.)
-3. **Route each ticket to its executor subagent** — don't execute in the main thread. `claim`, spawn the
-   ticket's `sidequest-exec-<effort>` at its derived model, let it do the work and `done`, repeat — the
-   board stays the source of truth for what's left. See "Execute in a routed subagent by default" and
-   "Complexity-driven routing" below for why.
+Scout first only when the surface is genuinely unfamiliar AND large — a quick read of the obvious
+files usually beats spawning explorers. Keep any scout proportional: one or two read-only explorers
+for a big unknown subsystem, none for a task whose files you can already name.
 
-This is the point of having the board: the plan is visible, survives context loss, and other agents can
-pick up unblocked pieces. Don't skip it for anything non-trivial. For a genuinely trivial one-step
-change, just do it — no need to ticket everything (and no story).
+The point of the board: the plan is visible, survives context loss, and other agents can pick up
+unblocked pieces. For a genuinely trivial one-step change, just do it — no ticket ceremony.
 
-sidequest is a Trello-light quest log. Tickets live in a central store under `~/.claude/sidequest`
-(keyed by project path), and a bundled dashboard shows them as a live Kanban board — every project at
-once. Everything is driven by one CLI: `bin/sidequest.js`.
+If the repo already uses Jira/Linear/GitHub Issues, that tracker owns the deliverable; sidequest is
+still your local execution ledger — see
+[references/external-trackers.md](references/external-trackers.md).
 
-## Works alongside an external tracker (Jira / Linear / GitHub Issues)
+## Finding the CLI, and preferring the MCP tools
 
-A repo already using Jira (or Linear, or GitHub Issues) does **not** make sidequest redundant — they
-track different things, so use both. Don't skip the board just because the work is "already tracked"
-somewhere; that reflex is exactly how the decompose-and-fan-out discipline gets dropped.
+The SessionStart hook injects the **resolved absolute command** (`node "<path>/bin/sidequest.js"`)
+into your context — use exactly that with the Bash tool. In this file, `sidequest` is shorthand for
+that prefix. Commands default to the current project (`$CLAUDE_PROJECT_DIR`); add
+`--project "<path-or-slug>"` for another board.
 
-- **The external tracker owns the deliverable.** It's the system-of-record humans read: the story, the
-  acceptance criteria, the status the team reports on. You don't replace it, and you usually don't file
-  there on the model's behalf.
-- **sidequest owns your local execution.** It's the agent's working ledger for *this* session: how you
-  cut the Jira item into parallel-safe pieces, fan subagents out over them, coordinate claims across
-  agents so nothing collides, and write spike findings back as comments that outlive your context.
-  None of that belongs in Jira, and none of it happens on its own.
+When tools named **`mcp__plugin_sidequest_board__*`** are in your toolset, **prefer them over the
+Bash CLI** for board actions — same store, same rules (complexity+why on `add`, effort guard on
+`claim`, atomic claiming), but structured JSON in/out, one tool approval instead of a Bash prompt per
+call, and no shell-quoting trap (multi-line markdown bodies are plain strings). The CLI remains for
+humans, `dashboard`/`serve`, and the headless `work` drain.
 
-**How to run both, in practice:**
-
-1. Take the external item (e.g. `CTR-13316`) and, if it's more than a trivial change, **decompose it
-   into local sidequest tickets** — one per independent piece, `--file`-scoped, same as any other plan.
-   Mirror the external ref in the title so the link is obvious: `sidequest add -t "CTR-13316: guard
-   ILIKE against <3-char variants" ...`.
-2. **Scout in parallel, then fan out** over the independent pieces exactly as you would without Jira
-   (see "Decompose for parallelism" and "Fan out over independent tickets"). The presence of a Jira
-   ticket changes nothing about how you parallelize the work.
-3. **Record findings on the sidequest ticket**, not just in the PR — root cause, `file:line`, what you
-   ruled out — so a later agent (or you, post-compaction) can pick it up.
-4. When the work lands, update the **external** tracker/PR as the team expects; the sidequest tickets
-   were your scaffolding and can just be marked `done`.
-
-The short version: **Jira says *what* to build; sidequest is *how you execute it* here.** One doesn't
-substitute for the other.
-
-## Finding the CLI
-
-You do **not** need to hard-code the path. When the user mentions the board or a ticket, the sidequest
-capture hook injects the **resolved absolute command** into your context, shown as:
-
-```
-node "<absolute path>/bin/sidequest.js"
-```
-
-Use exactly that. Run it with the **Bash tool**. (If for some reason it isn't in your context, the CLI
-is `bin/sidequest.js` inside the installed `sidequest` plugin directory; invoke it with `node`.) In the
-commands below, `sidequest` is shorthand for that `node "…/bin/sidequest.js"` prefix.
-
-The board a command acts on defaults to `$CLAUDE_PROJECT_DIR` (the current project), so you rarely pass
-a project. Add `--project "<path-or-slug>"` to target another board.
-
-## Prefer the MCP tools when they're available
-
-sidequest also ships an **MCP server**, so when tools named **`mcp__plugin_sidequest_board__*`** are in
-your toolset (`…__list`, `…__ready`, `…__add`, `…__claim`, `…__next`, `…__done`, `…__release`,
-`…__comment`, `…__ask`, `…__comments`, `…__link`, `…__assign`, `…__models`, `…__projects`), **use them
-instead of the Bash CLI** for board actions. They act on the exact same store and enforce the same rules
-(complexity+why required on `add`, the effort-drift guard on `claim`, atomic claiming), but they're
-cheaper and cleaner: one tool approval instead of a Bash prompt per call, structured JSON in and out, and
-**no shell-quoting trap** — pass a multi-line markdown `description`/`body` as a plain string with real
-newlines, no heredoc. `add`/`update`/`claim`/`done` take the same fields as the CLI flags below (e.g.
-`{ title, complexity, why, files: [...] }`, `{ ref, by, effort }`). Everything the rest of this skill
-teaches — decompose, score, claim-before-work, fan out — is identical; only the transport changes.
-
-The **CLI is still fully supported** (it's what humans use and what the examples below show); reach for it
-when the MCP tools aren't present, for `dashboard`/`serve`, or for the headless `work` drain. If both are
-available, the MCP tools are the default for routine board actions.
-
-## Where things live on disk (never scan from root to find them)
-
-- **The CLI**: `plugins/sidequest/bin/sidequest.js` under the sidequest plugin — invoke it as
-  `node "<path>/plugins/sidequest/bin/sidequest.js"` (see "Finding the CLI" above; the capture hook
-  already hands you the resolved path).
-- **Ticket data**: a central store outside any repo — root `~/.claude/sidequest` by default, overridable
-  with the `SIDEQUEST_HOME` env var. Under it: `projects/<slug>/tickets/<id>.json` (one file per
-  ticket) and `projects/<slug>/meta.json`.
-- **Attachment images**: `projects/<slug>/assets/<ticket-id>/<filename>` under that same root. To
-  resolve one from a ref like `SQ-12`, run `sidequest list --json` (or `--json` on any listing
-  command), find the ticket, and read its `project` slug plus the ticket's internal `id` and its
-  `assets` array — then join `<root>/projects/<slug>/assets/<id>/<filename>`. Don't guess the filename
-  or its location.
-- **Never run a full-disk scan** (`find /`, `find / -iname ...`, or similar) to locate the CLI, the
-  data dir, or an attachment. All three live at the fixed, known locations above — go straight there.
+**Where things live** (never scan the filesystem from root to find them): the CLI at
+`plugins/sidequest/bin/sidequest.js` under the installed plugin; ticket data under
+`~/.claude/sidequest` (override: `SIDEQUEST_HOME`) as `projects/<slug>/tickets/<id>.json`; attachment
+images under `projects/<slug>/assets/<ticket-id>/` (resolve via `sidequest list --json` — see
+[references/board-features.md](references/board-features.md)).
 
 ## Open the dashboard
-
-When the user asks to see the board/dashboard/kanban:
 
 ```bash
 sidequest dashboard
 ```
 
-This starts the local server if it isn't already running (it's idempotent — it reuses a running one),
-opens the user's default browser to the board, and prints the URL. **Report the URL** it prints in case
-the browser didn't pop up. The server binds to `127.0.0.1` only; it's a private, local tool.
+Idempotent — starts the local server if needed, opens the browser, prints the URL. **Report the URL.**
+Binds to `127.0.0.1` only.
 
 ## File a ticket
 
 ```bash
-sidequest add -t "Contact form does not send" -d "Submit does nothing; no email arrives." -p high -l bug -l frontend \
+sidequest add -t "Contact form does not send" -d "Submit does nothing; no email arrives." -p high -l bug \
   --complexity 4 --why "one form handler + its endpoint; reproduce, fix, verify the mail path"
 ```
 
-- `-t` title (required) · `-d` description · `-p` priority `low|normal|high|urgent` (default `normal`)
-- `--complexity 1-10` + `--why "<motivation>"` (BOTH required — routing is derived from the score; see
-  "Complexity-driven routing" below for the rubric; `--model`/`--effort` are not accepted)
-- `-l` label (repeat for several) · `-s` status `todo|doing|done` (default `todo`)
-- `-i` image path (repeat for several) — attach a pasted screenshot by its file path
+- `-t` title (required) · `-d` description · `-p` `low|normal|high|urgent` · `-l` label (repeatable)
+- `--complexity 1-10` + `--why "<motivation>"` — BOTH required; routing is derived from the score
+  (`--model`/`--effort` are rejected). See "Complexity-driven routing" below.
+- `-s` status `todo|doing|done` · `-i` image path (repeatable) · `--file` scope (repeatable) ·
+  `--story US-n`
 
-**Descriptions are developer-to-developer technical specs — write them as one developer handing work
-to another, never as a project manager summarizing.** "Improve the checkout flow" is not a ticket; a
-ticket says *which* files and functions, *what* behavior changes (inputs → outputs, edge cases), and
-*how to verify*. Concretely, a description must carry:
-- **Where**: the exact files/functions/anchors the work lands in (you often know — say so).
-- **The contract**: what changes at a code level — inputs → outputs, edge cases, error behavior.
-- **Bounds**: constraints, known out-of-scope, what must NOT change.
-- **Verification**: the command, test, or reproduction that proves it done.
-- **Bug tickets** additionally need the reproduction (what you did / what happened / what you
-  expected); **spikes** state what's actually unknown and why it matters.
+**Descriptions are developer-to-developer specs, never a PM summary.** A ticket says *which* files and
+functions (**Where**), *what* changes at a code level — inputs → outputs, edge cases, error behavior
+(**Contract**), what's out of scope or must not change (**Bounds**), and the command/test/reproduction
+that proves it done (**Verify**). Bugs additionally carry the reproduction; spikes state what's
+actually unknown and why it matters. **Scale the spec inversely to the executor's tier**: work routed
+to a cheap tier needs a near-patch-level spec — exact anchors, expected strings, precise verification
+commands — because the spec substitutes for judgment. **Everything you already know goes in the
+description**: a weaker executor fails on missing context, not on the work itself, so front-load
+what your investigation found (paths, the surrounding contract, the gotcha you spotted) instead of
+letting the executor re-derive it. Too little detail to write that? Investigate until you have it, or
+ask a quick clarifying question — never file a vague ticket.
 
-**Scale the spec to the executor, inversely.** The lower the tier that will work the ticket (its
-derived routing), the *more* complete the description must be — a cheap executor supplies less
-judgment, so the spec substitutes for tier. Work routed far below the filer should read near
-patch-level: exact anchors, exact expected strings, the precise verification commands. This is the
-flip side of decompose-for-parallelism: a well-shrunk ticket *is* mostly its spec.
-
-If you don't have enough of that detail, ask a quick clarifying question rather than filing a vague
-ticket — a thin ticket just costs the next reader (you, another agent, or the user) another round trip.
-
-**Descriptions and comments render full markdown** in the dashboard — headings, ordered/unordered
-lists, fenced code blocks, blockquotes, `[links](url)`, and inline `**bold**`/`*italic*`/`` `code` ``.
-Structure the spec with it: a short lead line, then headings or a list for Where / Contract / Bounds /
-Verify, bullets for enumerations, fenced blocks for commands or expected output, backticks for file
-paths and identifiers. It should aid the reader, not be decoration — reach for structure because the
-spec needs it, not to fill every line.
-
-**CRITICAL — use real newlines, never a literal `\n`.** A multi-line `-d`/`-m` value needs actual line
-breaks: a shell heredoc, or `$'...\n...'` quoting. The two literal characters backslash-n render as
-text in the dashboard, not a line break — that exact bug is why this guidance exists. For example:
+Descriptions and comments render **full markdown** in the dashboard — use headings/lists/fenced blocks
+when the spec needs structure. **CRITICAL: use real newlines, never a literal `\n`** — the two
+characters backslash-n render as text. Multi-line `-d`/`-m` values need a heredoc or `$'...'` quoting
+(MCP tools take plain strings with real newlines, no escaping):
 
 ```bash
 sidequest add -t "Contact form does not send" --complexity 4 --why "one handler + its endpoint" -d "$(cat <<'EOF'
 ## Where
 `src/routes/contact.ts` — the `POST /contact` handler
-
-## Contract
-- Submit currently no-ops; it should call the mail service and return 200 on success, 4xx on validation failure.
 
 ## Verify
 `curl -X POST localhost:3000/contact -d '...'` and confirm an email arrives.
@@ -206,502 +134,187 @@ EOF
 )"
 ```
 
-For a side issue the user tosses out **while you're mid-task** ("oh, and the footer link is broken"),
-don't stop your current work: spawn the **`ticket-filer`** subagent (ideally `run_in_background: true`)
-with the issue text, any pasted image path, and the CLI command. It files the ticket while you keep
-going. The capture hook reminds you of this and hands you the image path.
+For a side issue raised **while you're mid-task** ("oh, and the footer link is broken"), don't stop:
+spawn the **`ticket-filer`** subagent (`run_in_background: true`) with the issue text, any pasted
+image path, and the CLI command. **Filing a ticket is not a request to work it** — "make a ticket for
+X" means file it and stop.
 
-## User stories
-
-A **user story** groups several tickets that share a goal and color-codes them together on the board.
-Reach for one when a request breaks into multiple tickets (see "Plan substantial work" above); skip it
-for a lone ticket.
+## List / update / close
 
 ```bash
-sidequest story add -t "Checkout revamp" [-d "..."] [--color teal]   # prints its US-n ref
-sidequest story list                                                  # stories + color + ticket count
-sidequest story show US-1                                             # the story and its tickets
-sidequest story update US-1 -t "New title" [--color "#7a5ba8"]        # rename / recolor
-sidequest story rm US-1                                               # delete (member tickets detached)
+sidequest list                    # this project, grouped by column
+sidequest list --status todo      # one column
+sidequest projects                # every board with open counts
+sidequest update SQ-3 --status done   # move (todo|doing|done); also -p, -t, -d, -l
+sidequest rm SQ-3                 # delete
 ```
 
-- **Attach a ticket to a story**, at creation or later:
-  `sidequest add -t "..." --story US-1` · `sidequest update SQ-3 --story US-1` ·
-  `sidequest update SQ-3 --story none` (to clear it).
-- **Color** is optional — a distinct one is auto-assigned per story. Override with a hex (`#7a5ba8`) or a
-  name: `terracotta, teal, violet, olive, rose, steel, amber, green`.
-- On the dashboard each card wears its story's color (a top rail + a chip), a **Story** filter in the
-  toolbar narrows the board to one story, and the ticket editor has a **Story** field (pick, clear, or
-  create one inline).
-
-## List tickets
-
-```bash
-sidequest list                 # this project, grouped by column
-sidequest list --status todo   # only one column
-sidequest projects             # every board with open counts
-```
-
-Add `--json` to any of these when you want to read the data rather than show it.
-
-## Update / move / close a ticket
-
-Reference a ticket by its ref (`SQ-3`) or id:
-
-```bash
-sidequest update SQ-3 --status done                 # move across columns (todo|doing|done)
-sidequest update SQ-3 -p urgent                      # change priority
-sidequest update SQ-3 -t "New title" -d "New body"   # edit text
-sidequest update SQ-3 -l bug -l regression           # replace labels
-sidequest rm SQ-3                                     # delete
-```
-
-"Close", "mark done", "ship it", "resolve" → `--status done`. "Start", "in progress", "working on it"
-→ `--status doing`.
+Add `--json` to read data instead of showing it. Add `--brief` on `list`/`ready` (it implies
+`--json`) for the compact shape: ref, title, status, priority, complexity, model, effort, files,
+claim, `blockedBy`, a `comments` count, and `awaitingReply`. No description bodies, no thread
+contents. **Default to `--brief` for routine orchestration reads**; drop it only when you actually
+need bodies. "Close / mark done / ship it" → `--status done`. "Start / in progress" → `--status
+doing`.
 
 ## Work a ticket (safe with other agents)
 
-The board may be shared — other Claude sessions, other tabs, or teammates can be working it too. So a
-ticket must be **claimed** before you touch it, and claiming is **atomic**: two workers can never both
-win the same ticket.
-
-**Never start work on a ticket you haven't successfully claimed.** The claim is the check that it's
-still there and still free — don't skip it just because you filed the ticket yourself a moment ago.
+The board may be shared — other sessions or teammates can be working it too. A ticket must be
+**claimed** before you touch it, and claiming is **atomic**: two workers can never both win the same
+ticket. **Never start work on a ticket you haven't successfully claimed**, even one you just filed.
 
 ```bash
 sidequest next --by <you>              # atomically claim the top-priority available ticket
 sidequest claim SQ-3 --by <you>        # or claim a specific one
-#   ... spawn the ticket's routed executor to do the work (default; see "Execute in a routed subagent") ...
-sidequest done SQ-3 --by <you> --model <tier> --effort <level>   # mark done + stamp who/what worked it
+sidequest done SQ-3 --by <you> --model <tier> --effort <level>   # finish + stamp who/what worked it
 sidequest release SQ-3 --by <you>      # or drop it unfinished (optionally --status todo)
 ```
 
-- **`--by` must be genuinely unique to this session — never a short descriptive label.** A claim only
-  fails when `held.by !== by`; re-claiming under the **same** `by` that already holds it is treated as
-  the same worker resuming and silently succeeds. If two *independent* sessions both pick a generic
-  label like `"claude"` or `"claude-orchestrator"`, the atomic-claim guarantee never trips — each
-  session believes it alone owns the ticket, and you get two workers silently editing the same feature.
-  Generate a random per-session token once (e.g. `claude-<8 random hex chars>`) and reuse *that exact
-  string* for every claim/done/release in the session — don't hand-pick a plain name.
-- **If a claim fails**, the CLI says why (`already claimed by X`, `already done`, `no longer exists`) and
-  exits non-zero. **Do not work that ticket** — pick another, or stop. This is the whole safety
-  guarantee: it never hurts if another agent grabbed it first — but only when identities don't collide.
-- **Before a large fan-out** ("fix everything on the board"), run `sidequest list --status doing` first.
-  Tickets already `doing` under a `--by` you don't recognize as your own subagents are a sign another
-  session is already working the board — tell the user and confirm before also diving in, rather than
-  silently duplicating their work.
-- **Delegate by default.** After claiming, spawn the ticket's routed executor to do the work while you
-  orchestrate; mark it `done` once it reports back. Doing it in the main thread instead is the exception
-  (trivial changes only) — see "Execute in a routed subagent by default".
-- **Stale claims** (a worker that crashed or wandered off) are reclaimable after a timeout
-  (`SIDEQUEST_CLAIM_TTL_MIN`, default 60 min); `--force` overrides a live claim only when you're sure.
-- **Claims auto-release when your session ends.** A bundled `SessionEnd` hook releases every ticket this
-  session still holds in `doing` back to `todo` the moment the session ends — so a dependent never waits
-  out the full TTL just because you closed the terminal mid-work. It's session-scoped and safe (it only
-  touches this session's own claims), so you don't manage it; the TTL stays the backstop for anything the
-  hook never saw. Registration is automatic (the CLI/MCP read `$CLAUDE_CODE_SESSION_ID`), so you don't
-  pass a session flag. `sidequest reconcile` runs the same release by hand if you ever need it.
+- **`--by` must be genuinely unique to this session** — generate a random token once (e.g.
+  `claude-<8 hex>`) and reuse that exact string all session. A claim only fails when `held.by !== by`,
+  so two sessions both using a generic label like `"claude"` silently coexist as the same worker and
+  the atomicity guarantee never trips.
+- **If a claim fails** (already claimed / done / gone), **do not work that ticket** — pick another or
+  stop.
+- **Read the thread before working a ticket** (`sidequest comments <ref>`) — a prior agent may have
+  left exactly the context you need.
+- **Stale claims** are reclaimable after a TTL (`SIDEQUEST_CLAIM_TTL_MIN`, default 60 min). Claims
+  this session still holds auto-release back to `todo` when the session ends (bundled SessionEnd
+  hook); `sidequest reconcile` runs the same release by hand.
 
-## Decompose for parallelism (lower the difficulty on purpose)
+## Route execution down; keep the loop tight
 
-When you plan a story (see "Plan substantial work"), don't just split by topic — split so the pieces
-are **small, file-disjoint, and cheap to execute**. The goal is twofold: pieces that can run **in
-parallel without touching each other**, and pieces simple enough that the required tier **drops** —
-one big scary ticket an opus must grind through becomes N precise tickets a sonnet (or lower) can
-knock out simultaneously. The thinking stays at the top; the labor gets cheap and wide.
+Every ticket is scored and routed to a model×effort tier (below), and the economics are the point:
+**the orchestrator (this thread) is usually the most expensive model in the session; the stamped
+tiers are cheaper.** Executing ticket labor inline pays orchestrator prices for laborer work and
+drags tool output into the planning context — so **route essentially all real execution to each
+ticket's stamped tier**. Inline only a genuinely trivial one-step change (a one-liner, a rename)
+where the spawn round-trip costs more than the work itself.
 
-1. **Cut along file/module boundaries**, not conceptual ones. "CLI part", "dashboard part", "store
-   part" parallelize; "first half / second half of the feature" doesn't.
-2. **Declare each ticket's file scope** when filing: `sidequest add ... --file bin/cli.js --file lib/`
-   (repeatable; a directory prefix covers everything under it). This is what makes independence
-   *mechanical* instead of guesswork.
-3. **Shrink until the complexity drops.** If a piece still scores 7+, it's usually two pieces — a
-   small design/contract decision (high score) and a mechanical application of it (low score). The
-   score is what routes each piece to the right tier, so shrinking scores is shrinking cost.
-4. **Shape the story as: design → wave(s) → integrate.** A top-tier design/contract ticket blocks the
-   wave; the parallel executor tickets form the wave(s); an integration/verify ticket depends on all
-   of them. Encode that with `depends-on` links so `ready` naturally serializes the phases.
+**The orchestrator keeps the thinking; each executor owns its ticket.** Decision-level investigation
+— root-causing across findings, deciding the decomposition, writing the specs, reviewing and
+integrating what comes back — stays in this thread: its value is integration across pieces, and
+pushing it down just makes a cheap model do the real reasoning and compress it lossily. Breadth-first
+discovery *in service of* that plan (which files touch X, scanning logs for the needle) is what you
+delegate — and a scout returns **compressed findings** (a pointer list or short summary, ~1–2k
+tokens), never transcripts. Once a ticket is cut with a self-contained spec, its executor owns the
+within-ticket work end to end — don't pull ticket-internal digging back up here.
 
-## Fan out over independent tickets (do this by default)
+**The shape is a LOOP, not a hand-off.** Orchestrator spawns a wave → executors return terse reports
+*quickly* → orchestrator verifies, integrates, re-plans, spawns the next wave. Many short round-trips
+beat one long autonomous run. **Verify by artifact, not by claim** — an executor report cites the
+actual verification output (the test line, the diff), and you spot-check it; cap how much you fan out
+in parallel at what you can actually verify. The failure mode to prevent is the executor
+mini-session: a worker that runs for ten minutes re-discovering context, broadening scope, and
+re-verifying the world. You prevent it from the spawn side:
 
-**Fan out at more than the ticket stage — but size it to the task.** This is the other half of running
-subagent workflows: independent tickets worked at once, as teams of sub-agents, instead of grinding
-through them one at a time. Parallelism isn't a one-time move reserved for independent tickets. Wherever
-a stage has genuinely independent work, prefer concurrent
-subagents over a long serial grind: a couple of read-only explorers mapping different parts of a
-codebase, parallel reproductions of a bug across inputs, parallel verification of separate changes. The
-instinct to catch is "I'm about to do a dozen sequential reads/edits that don't depend on each other" —
-that's a fan-out. Stay proportional though: parallelism costs tokens and orchestration overhead, so
-don't spawn a subagent for trivial, dependent, or same-file work. A bit of parallel investigation and
-some parallel execution — not a swarm for everything.
+- **The ticket is the spec.** File it with exact anchors and the precise verify command (the cheaper
+  the tier, the more patch-level the spec — see "File a ticket"). A well-specced ticket leaves the
+  executor nothing to wander on.
+- **Scope the spawn prompt**: which files, which verify command, what "done" looks like, and what the
+  executor does NOT need (e.g. "no comment thread exists — skip reading it"; you know the count from
+  the `--brief` read).
+- **Executors bounce back, they don't grind.** An executor that hits ambiguity, growing scope, or two
+  failed attempts should release + report fast so you can re-scope or re-route — that's built into
+  the executor agents.
+- **Batch small same-tier tickets into ONE executor.** When a wave holds several small tickets all
+  stamped with the *same* model+effort, spawn one executor with the whole list of refs; it claims →
+  works → dones them in sequence. One spawn's overhead amortized over N tickets. Different stamped
+  tiers don't batch — split per tier.
+- **Parallel fan-out — one executor per ticket, spawned in a single message** — when `ready` shows a
+  wave of genuinely independent tickets big enough to justify a spawn each. Atomic claiming is what
+  makes this safe. Keep dependent or same-file work serial (that's what `depends-on` links and
+  `--file` scopes are for).
 
-**Fan out with NAMED subagents, always.** Every worker you spawn concurrently gets a unique `name`
-(lowercase-hyphens, e.g. `explorer-cli`, `exec-sq12`), and you spawn them as multiple named subagents in
-a SINGLE message. Naming is what makes each one addressable: it runs in its own isolated context, shows
-up in the fleet view (filter with `a:<name>`), and is independently resumable via `SendMessage {to:
-name}` — which auto-resumes it in the background with its full history intact. Never spawn an anonymous
-or generic worker. Note the built-in **Explore/Plan** agents are one-shot and NOT resumable, so when a
-scout's work needs to be picked back up, use a general-purpose or custom named agent (e.g.
-`code-explorer`) instead.
+A ticket is **ready** when it's unclaimed, unblocked, not done, not archived — `sidequest ready
+--json --brief` lists exactly this set, partitioned into **parallel-safe waves** by declared file
+scope. Fan out one wave at a time: read the wave, spawn, wait, re-run `ready`, repeat. Before a large
+fan-out, check `sidequest list --status doing --brief --json` — claims under a `--by` you don't
+recognize mean another session may be working the board; flag it to the user first.
 
-**A substantive investigation belongs on a ticket, not in an ad-hoc agent.** A cheap read-only scout
-(a couple of explorers building a quick map) is ephemeral — its output feeds your next decision and
-that's fine. But when an investigation is real work whose *result matters later* — a root-cause hunt, a
-spike, a "figure out how X works before we touch it" — file it as a **spike ticket** and let the
-investigator claim it, dig, and **write its findings back as a detailed comment** (see "Comments &
-questions"). Two parallel investigators become two spike tickets, each commenting what it found. The
-result then lives on the board — inspectable, and readable by every other agent — instead of evaporating
-with the orchestrator's context the moment the run ends.
+The main thread's job is decompose, score, spec, spawn, integrate. Larger orchestration shapes
+(workflows — opt-in, you propose rather than launch — and agent-teams caveats):
+[references/orchestration.md](references/orchestration.md).
 
-When several tickets are **ready and independent**, **work them in parallel** — do not grind through
-them one at a time. This is safe precisely because claiming is atomic: each subagent claims a different
-ticket, and any race just sends the loser to the next one.
-
-A ticket is **ready** when it's not done, not archived, not already claimed, and **not blocked** by an
-unfinished ticket (`sidequest ready` lists exactly this set). `ready` also groups the set into
-**parallel-safe waves** by declared file scope — no two tickets in a wave overlap — so fan out **one
-wave at a time**: spawn one executor per ticket in wave 1, wait for the wave, re-run `ready`, repeat.
-Tickets with **no declared scope** never mechanically conflict, so for those the old rule still
-applies: eyeball whether they'd edit the same files before parallelizing them.
-
-**How to fan out:**
-
-1. `sidequest list --status doing` — if tickets are already `doing` under a `--by` you don't recognize,
-   another session may be actively working this board; flag it to the user before proceeding.
-2. `sidequest ready --json` to see the fan-out-able set.
-3. Spawn **one NAMED subagent per ticket**, all in a single message (true parallel), each with a unique
-   `name` (lowercase-hyphens, e.g. `exec-sq12`), each told to:
-   `sidequest claim <ref> --by <unique-id>` → if the claim succeeds, do the work, then
-   `sidequest done <ref> --by <same-id> --model <its tier> --effort <its effort>` (stamp who/what
-   worked it); if it fails, stop (someone else has it).
-   Tie the agent's `name` to its `--by` id — both unique and session-scoped for the same worker — so the
-   named agent is addressable/resumable and its board activity is stamped by that same identity.
-   Give each a **genuinely random, session-scoped `--by`** — not just the ticket ref or a fixed label,
-   since a second independent session fanning out over the same board would derive the identical value
-   and silently coexist as the same worker (see the note on identity collisions above).
-4. When a batch finishes, the dependents it unblocked become ready — fan out over the next wave.
-
-**Unattended draining (`sidequest work`).** Interactive fan-out through the `sidequest-exec-*` agents is
-the default — it keeps the effort axis and stays in your session. But when the user wants the board worked
-*without* a live session (e.g. "just drain the backlog"), `sidequest work` spawns one headless
-`claude -p` run per ready ticket at its derived tier, wave by wave, until the board clears. Suggest it for
-that "work it while I'm away" ask; use `sidequest work --dry-run` first to show the plan. Headless runs
-can't pin reasoning effort (that's agent-frontmatter only), so they carry the ticket's **model** and run
-at that model's default effort — which is why it's the overflow/unattended path, not a replacement for
-interactive effort-pinned execution. It's safe beside anything else (claiming stays atomic).
-
-**Keep sequential** (don't parallelize) tickets that **depend on each other** or that **touch the same
-files** — parallel edits to one file collide. Link such tickets with `depends-on` so `ready`/`next`
-naturally serialize them. The **default parallelizer is named-subagent fan-out**: name every subagent
-and spawn them in one message (each addressable and resumable) — the Agent tool, always available. A
-**WORKFLOW** (`parallel()`/`pipeline()`) is the heavier, opt-in tool for a bigger, repeatable, or
-deterministic fan-out, sized small (<5) / medium (<15) / large (<50) within the runtime cap of 16
-concurrent / 1000 total per run. You don't launch a workflow on your own — it's gated on the user
-opting into that scale (an "ultracode" prompt, or an explicit ask). But you usually judge better than
-the user when one would genuinely help, so **when it would, SUGGEST it**: use `AskUserQuestion` to offer
-it as an option, explain *why* it fits here, the rough scale and the token cost, and let them pick.
-Raising the option is how the opt-in happens; staying silent when a workflow would clearly help is the
-mistake. The split: named subagents = turn-by-turn delegation you supervise and resume; workflows =
-larger deterministic orchestration where results stay in script vars and only the final output returns.
-
-## Execute in a routed subagent by default (~95% of the time)
-
-The main thread is a single fixed model. sidequest scores every ticket and routes it to the **best
-model×effort tier for that specific task** — so the moment you execute a ticket in the main thread, you
-throw that routing away: you run laborer work at orchestrator prices, or an underpowered model on
-something hard. Don't.
-
-**Default: the main thread orchestrates, a routed subagent executes.** In practice, the main thread
-stays the orchestrator and the tickets it spawns out become the actual labor. Plan and score on the
-board, then for each ticket spawn its executor as a **NAMED** subagent (`sidequest-exec-<effort>` at the
-ticket's derived model, with a unique `name` per ticket, e.g. `exec-<ref>`) to claim → do → verify →
-done — the name keeps it addressable and resumable. For a whole wave or a large batch, drive those same
-named executors as a **workflow** sized to complexity rather than hand-spawning one at a time. Keep ~95%
-of real execution off the main thread; the main thread's job is decompose, score, spawn, and integrate.
-
-**The ~5% you still do yourself:** genuinely trivial one-step changes (complexity 1–2) where spawning
-costs more than the work, plus the orchestration itself. "It's easier to just do it here" is exactly the
-reflex this rule exists to catch.
-
-This is a **separate reason from parallelism**. Even a single, serial ticket belongs in a routed
-subagent — routing is about running each task on the *right* model, not only about running many at once.
-
-## Under agent teams, spawn OUR executor — never a generic teammate
-
-If this session has **agent teams** on (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` — a **per-user** flag,
-set in the user's `settings.json` `env` block or shell; not every collaborator has it), your parallel
-workers spawn as manageable **teammates / background agents** instead of plain subagents. The routing
-rules below do **not** change, and one thing is critical: a teammate is a real sidequest executor **only
-if it has BOTH the correct agent type AND a unique `name`**. Spawn each worker as the ticket's
-**`sidequest-exec-<effort>` agent type with `model: <tier>` and a unique `name`** (lowercase-hyphens,
-e.g. `exec-sq12`) — the same `subagent_type` + `model` you'd use for a subagent, plus the name that makes
-it addressable. A plugin agent definition is a valid teammate type: its body is appended as the
-teammate's instructions and its `tools`/`model` are honored; the `name` is what makes it trackable in
-the fleet view and resumable via `SendMessage`.
-
-**The failure to avoid** (the bug this section exists for): letting the "spawn a team" reflex launch
-**default/generic teammates** with no agent type — they show up as bare "background agents" with just a
-task description. A generic OR unnamed teammate throws away the executor protocol *and* the tier routing
-*and* addressability: it won't `claim`, won't verify, won't `done`, and you can't track or resume it. No
-anonymous or unnamed workers, ever — every ticket worker, subagent or teammate, is a named
-`sidequest-exec-<effort>` with its own unique `name` (haiku tickets: a plain agent with `model: haiku`,
-still named).
-
-**Caveats specific to teams:**
-- A teammate may **inherit the lead's reasoning-effort** instead of the effort your
-  `sidequest-exec-<effort>` name implies. Spawn the correctly-named executor regardless: the claim's
-  `--effort` check still enforces that the right-tier worker took the ticket, and the executor body
-  still runs. If the effort might not carry and it matters, also state it in the spawn prompt.
-- **Model does not inherit the lead** — always pass `model: <tier>` explicitly (you already do).
-- The flag is **per-user**, so the identical `sidequest-exec-<effort>` + `model` spawn must also work as
-  a plain subagent when it's off. It does — never depend on teams being on.
-- Ticket execution is focused claim→do→verify→report work: the **subagent** sweet spot. Agent teams
-  shine for research/debate/review. If teams is on and you're spawning teammates anyway, they must still
-  be `sidequest-exec` executors — not generic ones.
+**A substantive investigation belongs on a ticket.** A root-cause hunt or "figure out how X works"
+spike gets filed, claimed, and its findings written back as a comment — that's the deliverable; an
+uncommented investigation gets redone by the next agent. A quick ephemeral scout doesn't need a
+ticket.
 
 ## Complexity-driven routing (ENFORCED)
 
-You never pick a model or effort directly. **You score the task's COMPLEXITY (1–10) with a mandatory
-motivation, and sidequest derives which tier works it and how hard it thinks** — by mapping the score
-onto **one capability-ranked ladder** of model×effort rungs built from the tiers the user enabled in
-the model picker. The ladder is a single merged sequence, not per-tier bands: tiers overlap and cross
-over (`sonnet·xhigh` outranks `opus·low` — capability orders the rungs, not tier), and adjacent scores
-may share a rung. **Max effort is held out of the normal spread**: only complexity 10 on the top
-enabled tier gets `·max` (and 9 only at bias +5) — deliberately rare, per Anthropic's "use max
-sparingly for the hardest tasks." The derivation is live: toggling a tier instantly re-routes every
-open ticket. `sidequest models` prints the current ladder.
+You never pick a model or effort. **Score the task's COMPLEXITY (1–10) with a mandatory motivation**;
+sidequest maps the score onto a capability-ranked ladder of model×effort rungs built from the tiers
+the user enabled (tiers overlap and cross over — `sonnet·xhigh` outranks `opus·low`). Max effort is
+deliberately rare (complexity 10 only, per Anthropic's "use max sparingly"). The derivation is live —
+toggling a tier re-routes every open ticket. `sidequest models` prints the current ladder; mechanics
+and bias dial: [references/routing-details.md](references/routing-details.md).
 
-**One score, three coupled outputs.** The same complexity score drives not only the **model** and the
-**effort** (the ladder above) but also the **orchestration shape** — how you run the work. It's one
-continuous ladder: a low, serial one-off → a single NAMED subagent; the moment there's independent work
-that can run at once → PARALLELIZE it, **by default as named-subagent fan-out** (spawn several named
-subagents in one message — always available). A **WORKFLOW** (`parallel()`/`pipeline()`) is the heavier
-tool for a larger, repeatable, or deterministic run, sized small (<5) → medium (<15) → large (<50)
-within the cap of 16 concurrent / 1000 total. **Workflows are gated — you don't launch one on your own;
-the user opts into that scale** (an "ultracode" prompt, or an explicit ask). But you usually judge
-better than the user when a workflow would genuinely help, so **when you think one would, SUGGEST it**:
-use `AskUserQuestion` to offer it with concrete options, explain *why* it fits here, the rough scale and
-the token cost, and let them pick. Proposing it is how the opt-in happens; staying silent when a
-workflow would clearly help is the mistake. Default to named-subagent fan-out; propose a workflow when
-the shape calls for it.
+The scale is **absolute** — anchored, not "hard for me right now". The `--why` must reference the
+actual work (files, moving parts, unknowns), not restate the number:
 
-**Bias is the user's dial, not yours.** You always score complexity honestly against the absolute
-anchored scale below — bias tunes only HOW eagerly those scores escalate to pricier rungs, never what
-you score. The user sets it with `sidequest bias <n>` (or the dashboard slider): `-5` Frugal … `0`
-neutral (default) … `+5` Generous, gamma-curving the score→rung map. Extremes stay invariant:
-complexity 1 always hits the cheapest rung and 10 the top rung at any bias.
+- **1** — trivial: a one-line lookup, skimming logs for a fact.
+- **2–3** — routine: a single-file edit, a rename, a config bump.
+- **4–5** — everyday build: one area, a known pattern, a few edge cases (~5 ≈ a static page or plain
+  component).
+- **6–7** — hard: a multi-file feature or cross-cutting refactor with a contract multiple consumers
+  must respect.
+- **8** — gnarly: novel debugging with an unknown root cause; algorithm/architecture design under
+  real constraints.
+- **9–10** — frontier: research-grade problems with no established solution. Firing rarely is
+  intended.
 
-**Every ticket MUST be filed with `--complexity 1-10` AND `--why "<motivation>"` — sidequest errors
-without them, and `--model`/`--effort` are rejected as direct inputs.** The motivation must reference
-the actual work (files, moving parts, unknowns), not restate the number — writing it is what forces
-you to look at the task properly. The scale is **absolute** — anchored to concrete reference points,
-not to "hard for me right now":
+Normal day-to-day coding legitimately lands 1–7. If unsure, score lower.
 
-Each band maps to an effort/model rung (via the ladder) AND an orchestration shape (after the `→`;
-named-subagent fan-out is the default, a workflow is the opt-in tool you *propose* at the larger sizes):
+**Rules for working the board:**
 
-- **1** — trivial: summarizing a README, a one-line lookup, skimming logs for a fact. → inline, or a
-  single named subagent; nothing to parallelize.
-- **2–3** — routine: a single-file edit or script, a rename, a dedup, a config bump. → a single NAMED
-  subagent (serial one-off).
-- **4–5** — everyday build: one area, a known pattern, a few edge cases; **~5 anchors to simple HTML
-  work** — a static page, a form, a plain component. → a single named subagent, or a small **named
-  fan-out** if it splits into independent pieces.
-- **6–7** — hard: a multi-file feature or cross-cutting refactor — several coordinated edits, a
-  contract multiple consumers must respect, real edge cases. → decompose and fan out named executors
-  over the independent pieces; if that fan-out is sizable/repeatable, **propose a small–medium workflow**
-  (<5–<15).
-- **8** — gnarly: novel debugging with an unknown root cause, or designing an algorithm/architecture
-  under real constraints. → design-ticket → parallel named-executor wave → integrate; **propose a
-  medium workflow** (<15) for the wave.
-- **9–10** — frontier: developing new AI models, RL training, research-grade problems with no
-  established solution. **10 is the extreme end**, not "a hard day." → staged waves of named executors;
-  **propose a medium–large workflow** (<15–<50).
-
-Normal day-to-day coding legitimately lands **1–7**. Scores of **9–10 firing rarely is intended** —
-the top rung (·max effort) is reserved for genuinely extreme work, same spirit as Anthropic's own
-guidance to use max effort "sparingly for the hardest tasks." If you're unsure, score lower.
-
-```bash
-sidequest add -t "Apply the codemod" --complexity 2 --why "single mechanical transform over bin/cli.js, verified by node -c"
-sidequest add -t "Design the migration" --complexity 8 --why "reshapes the store contract; every consumer (CLI, server, dashboard) must stay compatible mid-rollout"
-sidequest update SQ-8 --complexity 5 --why "wider than scored: it also rewires the reader path"   # rescore needs a fresh why
-sidequest models        # the live ladder: which score routes to which tier·effort right now
-```
-
-**Rules for working the board — the same register as "never work a ticket you haven't claimed":**
-
-0. **Routing master switch first.** `sidequest models --json` → if `routing` is `false` the rules
-   below stand down: work any ticket yourself; derived tags are informational.
-1. **Route, don't self-execute — ~95% of the time.** Every non-trivial ticket runs in a NAMED executor
-   subagent, not the main thread: you cannot change your own model mid-run, so the spawn is the only way
-   each task lands on the model×effort scored for it. This holds even for a single serial ticket and even
-   when the derived tier equals yours (it still isolates context and composes the effort level). Only
-   genuinely trivial one-step changes stay in the main thread. Complexity already drives model×effort; it
-   ALSO drives the orchestration shape, and routing COMPOSES with it: a single ticket → one named
-   executor; a ready wave → many named executors spawned in one message (the default); a large or
-   repeatable batch → **propose a WORKFLOW** via `AskUserQuestion` (it's opt-in — you suggest, the user
-   approves) sized by complexity (small <5 / medium <15 / large <50). Decompose, score, fan out; don't
-   quietly do laborer work at orchestrator prices.
-2. **The ticket's derived `model`/`effort` ARE the routing** — they come stamped on every read
-   (`list`/`ready --json`), already shaped by the user's allowlist, so there is nothing to re-derive.
-   Cap at your own tier if the ladder tops out above you (`fable > opus > sonnet > haiku`), and only
-   spawn models that actually exist in your environment.
-3. **Map effort via the bundled executors:** spawn `subagent_type: sidequest-exec-<derived effort>`
-   **with** `model: <derived tier>` **and a unique `name:` per ticket** (lowercase-hyphens, e.g.
-   `exec-sq12`) — effort lives in the agent definition, model and name in the spawn; they compose. A
-   haiku-derived ticket has no effort: use a plain agent with `model: haiku` (still named).
-   **`<derived effort>` is the ticket's stamped `effort` verbatim, read from the FRESHEST `ready`/`list
-   --json` right before you spawn — never a level you judge fits better, and never one you carry over
-   from another ticket in the same fan-out.** Picking a different one (a disabled rung, hotter/cooler than
-   stamped, or another ticket's effort) is drift, and the executor guards against it: it claims with
-   `--effort <its baked level>`, and the board REFUSES the claim if that doesn't match the derived effort,
-   bouncing the ticket back for the correct-tier agent. Re-reading the stamped effort per ref immediately
-   before each spawn is what stops those refused-claim round-trips — match `sidequest-exec-<effort>` to
-   the ref's stamped effort exactly, especially when fanning out several at once, where it's easy to pair
-   the wrong exec with a ref.
-4. **Claim by tier:** `next --model X` / `ready --model X` hand out only tickets whose derived tier
-   is X — an executor never grabs work priced for another tier.
-
-**Decision procedure:** routing on? → read each ticket's derived `model`/`effort` from the freshest
-`ready`/`list --json` → cap at your tier → pick the orchestration shape by complexity (single named
-subagent / named fan-out in one message / small|medium|large workflow) → spawn `sidequest-exec-<that
-ref's exact effort>` (or plain agent for haiku) with `model: <tier>` and a unique `name` → executor
-claims → works → verifies → dones. Read the stamped effort per ref immediately before spawning, so the
-exec tier matches and the claim isn't refused.
-
-*Worked example:* main session = fable, haiku disabled; ticket `SQ-12 ⚙C3→sonnet·max`.
-`Agent(subagent_type: "sidequest-exec-max", model: "sonnet", name: "exec-sq12", prompt: claim SQ-12 →
-fix → verify → done)`. The user re-enables haiku later → the same open ticket re-reads as `C3→sonnet·low`
-or lower — always spawn from the freshest read.
-
-A ticket shows `⚙C<score>→tier·effort` on its card and in `list`/`ready`; the user shapes the ladder
-in the dashboard settings (gear → Available models), where the live mapping is displayed.
-Effort exclusion is per model, not global — a model×effort grid, so opus·medium can be off while
-sonnet·medium stays on. An excluded model×effort pair never appears in the derived ladder for that
-model.
+1. **Master switch first**: `sidequest models --json` → if `routing` is `false`, work any ticket
+   yourself; derived tags are informational.
+2. **The stamped `model`/`effort` on every read ARE the routing** — nothing to re-derive. Cap at your
+   own tier if the ladder tops out above you (`fable > opus > sonnet > haiku`); only spawn models that
+   exist in your environment.
+3. **Spawn `sidequest-exec-<stamped effort>` with `model: <stamped tier>` and a unique `name`.**
+   `<stamped effort>` is the ticket's `effort` **verbatim from a fresh `ready`/`list --json --brief`
+   read for that wave** — never a level you judge fits better, never carried over from another ticket.
+   The executor claims with `--effort <its baked level>` and the board **refuses the claim on a
+   mismatch**, bouncing the ticket back — re-reading per wave is what avoids those wasted round-trips.
+   A haiku-routed ticket has no effort: use a plain agent with `model: haiku` (still named).
+4. **Claim by tier**: `next --model X` / `ready --model X` hand out only tickets derived to X.
 
 ## Comments & questions
 
-Every ticket has a comment thread. Post one with `sidequest comment` or `sidequest ask` — the two
-have **different follow-up behavior**, so pick deliberately:
-
 ```bash
-sidequest comment SQ-3 -m "Reused the SQ-1 fixtures here."   # a note-to-self: keep working, no pause
-sidequest ask     SQ-3 -m "Cover the v2 API too?"            # addressed to the user: needs a reply
+sidequest comment SQ-3 -m "Reused the SQ-1 fixtures here."   # note-to-self: keep working, no pause
+sidequest ask     SQ-3 -m "Cover the v2 API too?"            # addressed to the USER: needs a reply
 sidequest comments SQ-3                                       # read the thread
 ```
 
-- **Write your findings back as a comment after any investigation or substantive change.** The report
-  you hand back to the orchestrator is ephemeral — it dies with that context. The durable, shareable
-  record is a ticket comment: what you examined, what you found, the **root cause with evidence**
-  (`file:line`), what you **ruled out**, and the fix or recommended next step. An investigation whose
-  result never got commented has to be redone by the next agent — so for a spike or a root-cause hunt,
-  the comment is the actual deliverable, not an afterthought.
-- **Read the thread before you work a ticket** (`sidequest comments <ref>`), and skim any linked or
-  related tickets' threads too. A prior or parallel agent may have already mapped the code, hit the dead
-  ends, or left the exact context you need — reading it first is far cheaper than rediscovering it.
-- **A plain `comment`** is a log entry for continuity (progress note, decision record, a thought for
-  later). It never blocks anything — post it and keep going.
-- **An `ask`** (or `comment --kind question`) is addressed to the user and means you need their
-  input before continuing. **`ask` only posts the question — it does not itself pause.** Follow it
-  with `sidequest await`:
-
-  ```bash
-  sidequest await SQ-3                          # blocks up to 120s (poll every 5s) for a reply
-  sidequest await SQ-3 --timeout 900 --poll 10  # a longer wait, polling less often
-  ```
-
-  `await` exits `0` with the new reply text once the user answers (through the dashboard), or exits
-  `1` on timeout if they haven't yet. **Do not just continue past your own question as if it were
-  answered.** On timeout, either `await` again (loop it, or use a longer `--timeout`) or tell the
-  user you're blocked on their reply and stop — don't guess and proceed. An ordinary follow-up
-  `comment` you leave yourself in between (e.g. a progress note) does not count as an answer; only
-  the user's own reply clears it.
-- Check `sidequest list` or `sidequest comments <ref>` for a "❓ awaiting reply" marker — that flags a
-  question of yours still unanswered, including ones asked earlier in a different session.
-- Comment bodies render full markdown, same as descriptions — reach for it when it aids scanning (a
-  ticket ref, a file path, a command, a short code block), not as a rule to follow everywhere. Use
-  real newlines for anything multi-line, never a literal `\n`.
-
-## Assign a ticket to the human
-
-Separate from an agent **claim** (atomic, TTL-bound, gates `ready`/`next`), a ticket can also carry a
-persistent **assignee** — normally the human user. Use this when the user says "assign this to me" or
-wants to track who owns a ticket, not who's actively working it:
-
-```bash
-sidequest assign SQ-3               # assign to "you" (the default human identity)
-sidequest assign SQ-3 --to Kenny    # or a specific name
-sidequest unassign SQ-3             # clear it
-```
-
-The dashboard shows an assignee chip on each card and has a filter (Everyone / Mine / Agents /
-Unassigned) in the board toolbar — "Agents" means a live claim (or a non-"you" assignee), "Unassigned"
-means neither. Assignment never expires and never blocks `claim`/`ready`/`next` — an agent can still
-claim and work a ticket that's assigned to the human.
-
-## Notifications & reminders
-
-The dashboard has an in-app notification inbox (the bell icon, top-right), backed by a persistent
-server-side queue:
-
-- **Background events** — Claude/CLI creating, moving, commenting on, or asking a question about a
-  ticket enqueues a notification automatically (subject to per-kind opt-in/out in the settings
-  popover). These show up in the bell inbox with an unread badge, even if the dashboard tab was closed
-  when the event happened. Nothing to do here — this is automatic. The inbox splits them into
-  **Needs you** (questions + reminders) and **Activity** (new tickets, moves, comments) so a question
-  never gets buried; a question also turns the bell badge red.
-- **Per-project mute.** A whole board's notifications can be turned off from the dashboard's settings
-  popover (on by default). A muted board queues **nothing** — no questions, comments, or status —
-  regardless of the per-kind settings, and its rail row shows a muted-bell mark. Useful to silence a
-  noisy background project without losing notifications everywhere.
-- **Reminders** — a time-based nudge on a ticket that later fires into the same inbox. Set one with the
-  CLI:
-
-  ```bash
-  sidequest remind SQ-3 --in 1h              # presets: 1h | 3h | tomorrow (9am)
-  sidequest remind SQ-3 --at "2026-07-05T09:00"   # or a specific date/time
-  sidequest unremind SQ-3                    # cancel a pending one
-  ```
-
-  (The dashboard's ticket editor offers the same presets as a "Remind me" control, plus a cancellable
-  chip, for the human doing it by hand.) The reminder fires into the live queue once its time passes —
-  the running dashboard server (`sidequest dashboard`/`serve`) needs to be up for the fire to be
-  noticed promptly, and it survives a server restart (one due while the server was down shows up on
-  the next tick after it's back).
-- Desktop toasts are a separate, independent opt-in (toggle in the settings popover, next to the bell) —
-  they fire alongside the same events but aren't required for the inbox itself to work.
-
-Use `remind` when the user says "remind me about this in an hour" / "ping me on this tomorrow" on a
-specific ticket — don't just leave a comment for that, since a comment doesn't fire anything at a later
-time.
+- **Write findings back as a comment after any investigation or substantive change** — root cause
+  with evidence (`file:line`), what you ruled out, the fix, how you verified. The orchestrator report
+  dies with its context; the comment is the durable record.
+- **An `ask` posts the question but does not itself pause** — follow it with `sidequest await SQ-3`
+  (blocks up to 120s; `--timeout 900 --poll 10` for longer). `await` exits 0 with the reply text, 1 on
+  timeout. **Never continue past your own unanswered question** — on timeout, `await` again or tell
+  the user you're blocked. Your own interim comments don't count as an answer.
+- A "❓ awaiting reply" marker in `list`/`comments` flags a still-unanswered question, including from
+  earlier sessions.
 
 ## Link tickets
 
-Relate tickets so the order of work is explicit — a link is stored on both tickets, so set it once
-from either side:
-
 ```bash
-sidequest link SQ-4 depends-on SQ-3   # SQ-4 is blocked-by SQ-3 (and SQ-3 blocks SQ-4)
-sidequest link SQ-1 blocks SQ-2       # the other direction
-sidequest link SQ-5 related SQ-6      # a non-blocking association
-sidequest unlink SQ-4 SQ-3            # remove it
+sidequest link SQ-4 depends-on SQ-3   # SQ-4 blocked by SQ-3 (stored on both sides)
+sidequest link SQ-1 blocks SQ-2
+sidequest link SQ-5 related SQ-6      # non-blocking association
+sidequest unlink SQ-4 SQ-3
 ```
 
-A ticket that's `blocked-by` an unfinished one is skipped by `sidequest next` and shown as blocked in
-`sidequest list`, so an agent grabbing top-priority work never picks up something that isn't ready yet.
+A ticket blocked by an unfinished one is skipped by `next` and excluded from `ready`.
 
 ## Guidelines
 
-- **Filing a ticket is not a request to work it.** "Make a ticket for X" / "add a bug for Y" means file
-  it and stop — don't claim or start solving it unless the user separately asks you to work the board
-  (or explicitly asks for both in the same breath, e.g. "file it and fix it now"). This applies doubly
-  to the `ticket-filer` subagent, which never touches code by design, but also to you: a freshly created
-  ticket sitting in `todo` is not an invitation to immediately `claim`/`next` it.
-- **Act, then report.** Run the command and tell the user the result (the ref, the new status, or the
-  URL). Don't ask which board unless it's genuinely ambiguous — default to the current project.
-- **Keep titles tight and concrete.** One line; put detail in `-d`.
-- **The dashboard is live.** It polls, so tickets you add from the CLI appear on an open board within a
-  couple of seconds — no refresh needed. New arrivals animate in.
-- **Don't invent tickets.** Only file what the user actually raised.
+- **Act, then report** — run the command, tell the user the result (ref, status, or URL). Default to
+  the current project's board.
+- **Keep titles tight**; detail goes in `-d`.
+- **The dashboard is live** — CLI changes appear on an open board within seconds.
+- **Don't invent tickets** — only file what the user actually raised.
+- Reminders (`sidequest remind SQ-3 --in 1h`) and human assignment (`sidequest assign SQ-3`):
+  [references/board-features.md](references/board-features.md).

--- a/plugins/sidequest/skills/sidequest/SKILL.md
+++ b/plugins/sidequest/skills/sidequest/SKILL.md
@@ -103,6 +103,23 @@ commands below, `sidequest` is shorthand for that `node "…/bin/sidequest.js"` 
 The board a command acts on defaults to `$CLAUDE_PROJECT_DIR` (the current project), so you rarely pass
 a project. Add `--project "<path-or-slug>"` to target another board.
 
+## Prefer the MCP tools when they're available
+
+sidequest also ships an **MCP server**, so when tools named **`mcp__plugin_sidequest_board__*`** are in
+your toolset (`…__list`, `…__ready`, `…__add`, `…__claim`, `…__next`, `…__done`, `…__release`,
+`…__comment`, `…__ask`, `…__comments`, `…__link`, `…__assign`, `…__models`, `…__projects`), **use them
+instead of the Bash CLI** for board actions. They act on the exact same store and enforce the same rules
+(complexity+why required on `add`, the effort-drift guard on `claim`, atomic claiming), but they're
+cheaper and cleaner: one tool approval instead of a Bash prompt per call, structured JSON in and out, and
+**no shell-quoting trap** — pass a multi-line markdown `description`/`body` as a plain string with real
+newlines, no heredoc. `add`/`update`/`claim`/`done` take the same fields as the CLI flags below (e.g.
+`{ title, complexity, why, files: [...] }`, `{ ref, by, effort }`). Everything the rest of this skill
+teaches — decompose, score, claim-before-work, fan out — is identical; only the transport changes.
+
+The **CLI is still fully supported** (it's what humans use and what the examples below show); reach for it
+when the MCP tools aren't present, for `dashboard`/`serve`, or for the headless `work` drain. If both are
+available, the MCP tools are the default for routine board actions.
+
 ## Where things live on disk (never scan from root to find them)
 
 - **The CLI**: `plugins/sidequest/bin/sidequest.js` under the sidequest plugin — invoke it as
@@ -278,6 +295,12 @@ sidequest release SQ-3 --by <you>      # or drop it unfinished (optionally --sta
   (trivial changes only) — see "Execute in a routed subagent by default".
 - **Stale claims** (a worker that crashed or wandered off) are reclaimable after a timeout
   (`SIDEQUEST_CLAIM_TTL_MIN`, default 60 min); `--force` overrides a live claim only when you're sure.
+- **Claims auto-release when your session ends.** A bundled `SessionEnd` hook releases every ticket this
+  session still holds in `doing` back to `todo` the moment the session ends — so a dependent never waits
+  out the full TTL just because you closed the terminal mid-work. It's session-scoped and safe (it only
+  touches this session's own claims), so you don't manage it; the TTL stays the backstop for anything the
+  hook never saw. Registration is automatic (the CLI/MCP read `$CLAUDE_CODE_SESSION_ID`), so you don't
+  pass a session flag. `sidequest reconcile` runs the same release by hand if you ever need it.
 
 ## Decompose for parallelism (lower the difficulty on purpose)
 
@@ -357,6 +380,15 @@ applies: eyeball whether they'd edit the same files before parallelizing them.
    since a second independent session fanning out over the same board would derive the identical value
    and silently coexist as the same worker (see the note on identity collisions above).
 4. When a batch finishes, the dependents it unblocked become ready — fan out over the next wave.
+
+**Unattended draining (`sidequest work`).** Interactive fan-out through the `sidequest-exec-*` agents is
+the default — it keeps the effort axis and stays in your session. But when the user wants the board worked
+*without* a live session (e.g. "just drain the backlog"), `sidequest work` spawns one headless
+`claude -p` run per ready ticket at its derived tier, wave by wave, until the board clears. Suggest it for
+that "work it while I'm away" ask; use `sidequest work --dry-run` first to show the plan. Headless runs
+can't pin reasoning effort (that's agent-frontmatter only), so they carry the ticket's **model** and run
+at that model's default effort — which is why it's the overflow/unattended path, not a replacement for
+interactive effort-pinned execution. It's safe beside anything else (claiming stays atomic).
 
 **Keep sequential** (don't parallelize) tickets that **depend on each other** or that **touch the same
 files** — parallel edits to one file collide. Link such tickets with `depends-on` so `ready`/`next`

--- a/plugins/sidequest/skills/sidequest/references/board-features.md
+++ b/plugins/sidequest/skills/sidequest/references/board-features.md
@@ -1,0 +1,72 @@
+# Board features: stories, notifications, reminders, assignment, attachments
+
+Read this for the exact commands behind stories, reminders, notifications, human assignment, or
+attachment-path resolution.
+
+## User stories
+
+A **story** groups several tickets that share a goal and color-codes them together on the board.
+Reach for one when a request breaks into multiple tickets; skip it for a lone ticket.
+
+```bash
+sidequest story add -t "Checkout revamp" [-d "..."] [--color teal]   # prints its US-n ref
+sidequest story list                                                  # stories + color + ticket count
+sidequest story show US-1                                             # the story and its tickets
+sidequest story update US-1 -t "New title" [--color "#7a5ba8"]        # rename / recolor
+sidequest story rm US-1                                               # delete (member tickets detached)
+```
+
+- Attach a ticket at creation (`sidequest add ... --story US-1`) or later
+  (`sidequest update SQ-3 --story US-1`; `--story none` clears it).
+- **Color** is optional — a distinct one is auto-assigned per story. Override with a hex or a name:
+  `terracotta, teal, violet, olive, rose, steel, amber, green`.
+- The dashboard shows each card with its story's color (top rail + chip), a **Story** filter in the
+  toolbar, and a Story field in the ticket editor.
+
+## Notifications
+
+The dashboard has an in-app notification inbox (the bell, top-right), backed by a persistent
+server-side queue:
+
+- **Background events** — Claude/CLI creating, moving, commenting on, or asking a question about a
+  ticket enqueues a notification automatically (per-kind opt-in/out in the settings popover), even if
+  the dashboard tab was closed at the time. The inbox splits **Needs you** (questions + reminders)
+  from **Activity** (new tickets, moves, comments); a question turns the bell badge red. Nothing for
+  you to do — this is automatic.
+- **Per-project mute** — a muted board queues nothing, regardless of per-kind settings; its rail row
+  shows a muted-bell mark.
+- **Desktop toasts** are a separate opt-in (settings popover), alongside the inbox.
+
+## Reminders
+
+```bash
+sidequest remind SQ-3 --in 1h                    # presets: 1h | 3h | tomorrow (9am)
+sidequest remind SQ-3 --at "2026-07-05T09:00"    # or a specific date/time
+sidequest unremind SQ-3                          # cancel a pending one
+```
+
+Use `remind` when the user says "remind me about this in an hour" — a comment doesn't fire anything
+later. The reminder fires into the live queue once its time passes; the dashboard server needs to be
+up for the fire to be noticed promptly, and it survives a server restart. The ticket editor offers
+the same presets as a "Remind me" control.
+
+## Assign a ticket to the human
+
+Separate from an agent **claim** (atomic, TTL-bound, gates `ready`/`next`), a ticket can carry a
+persistent **assignee** — normally the human. Use when the user says "assign this to me":
+
+```bash
+sidequest assign SQ-3               # assign to "you" (the default human identity)
+sidequest assign SQ-3 --to Kenny    # or a specific name
+sidequest unassign SQ-3             # clear it
+```
+
+The dashboard shows an assignee chip and a filter (Everyone / Mine / Agents / Unassigned).
+Assignment never expires and never blocks `claim`/`ready`/`next`.
+
+## Attachment images
+
+Stored under `<root>/projects/<slug>/assets/<ticket-id>/<filename>`, where `<root>` is
+`~/.claude/sidequest` (or `SIDEQUEST_HOME`). To resolve one from a ref like `SQ-12`: run
+`sidequest list --json`, find the ticket, read its `project` slug + internal `id` + `assets` array,
+then join the path. Don't guess the filename or scan the disk for it.

--- a/plugins/sidequest/skills/sidequest/references/external-trackers.md
+++ b/plugins/sidequest/skills/sidequest/references/external-trackers.md
@@ -1,0 +1,28 @@
+# Running sidequest alongside Jira / Linear / GitHub Issues
+
+Read this when the repo already has an external tracker and you're tempted to skip the board because
+the work is "already tracked". Don't — they track different things.
+
+- **The external tracker owns the deliverable.** It's the system-of-record humans read: the story,
+  the acceptance criteria, the status the team reports on. You don't replace it, and you usually
+  don't file there on the model's behalf.
+- **sidequest owns your local execution.** It's the agent's working ledger for *this* session: how
+  you cut the external item into parallel-safe pieces, coordinate claims across agents so nothing
+  collides, and write spike findings back as comments that outlive your context. None of that belongs
+  in Jira, and none of it happens on its own.
+
+How to run both, in practice:
+
+1. Take the external item (e.g. `CTR-13316`) and, if it's more than a trivial change, **decompose it
+   into local sidequest tickets** — one per independent piece, `--file`-scoped, same as any other
+   plan. Mirror the external ref in the title so the link is obvious:
+   `sidequest add -t "CTR-13316: guard ILIKE against <3-char variants" ...`.
+2. **Execute per the normal delegation rules** (main skill) — the presence of a Jira ticket changes
+   nothing about how you parallelize or route the work.
+3. **Record findings on the sidequest ticket**, not just in the PR — root cause, `file:line`, what
+   you ruled out — so a later agent (or you, post-compaction) can pick it up.
+4. When the work lands, update the **external** tracker/PR as the team expects; the sidequest tickets
+   were your scaffolding and can just be marked `done`.
+
+Short version: **Jira says *what* to build; sidequest is *how you execute it* here.** One doesn't
+substitute for the other.

--- a/plugins/sidequest/skills/sidequest/references/orchestration.md
+++ b/plugins/sidequest/skills/sidequest/references/orchestration.md
@@ -1,0 +1,93 @@
+# Orchestration: fan-out, workflows, agent teams, unattended draining
+
+Read this when you're about to run more than a couple of executors at once, when agent teams is on,
+when a workflow might fit, or when the user wants the board drained unattended. The baseline
+delegation rule (route execution down to each ticket's stamped cheap tier as short bounded runs,
+batch small same-tier tickets, fan out over independent waves, inline only trivial one-steps) lives
+in the main skill — this file is the detail on the bigger shapes.
+
+## Fan-out mechanics
+
+When several tickets are **ready and independent**, work them in parallel — one executor per ticket,
+all spawned in a **single message** (true parallel). This is safe precisely because claiming is
+atomic: each subagent claims a different ticket, and any race just sends the loser onward.
+
+- **Name every worker.** Each concurrent subagent gets a unique `name` (lowercase-hyphens, e.g.
+  `exec-sq12`). Naming makes it addressable: it shows in the fleet view (filter `a:<name>`) and is
+  resumable via `SendMessage {to: name}` with its history intact. Never spawn an anonymous worker.
+  Built-in Explore/Plan agents are one-shot and NOT resumable — when a scout's work must be picked
+  back up, use a general-purpose or custom named agent (e.g. `code-explorer`) instead.
+- **Tie the `name` to the `--by` id** — both unique and session-scoped for the same worker, so the
+  agent is addressable and its board activity is stamped by the same identity. The `--by` must be
+  genuinely random per session (not the ticket ref, not a fixed label): a second session fanning out
+  over the same board would derive the identical value and silently coexist as the same worker.
+- **One wave at a time.** `ready --json --brief` partitions the set into parallel-safe waves by
+  declared file scope — no two tickets in a wave overlap. Spawn wave 1, wait, re-run `ready`, repeat.
+  Tickets with no declared scope never mechanically conflict, so eyeball whether they'd edit the same
+  files before parallelizing them.
+- **Executor prompts stay lean**: the ref, the claim/done commands with the worker id, the stamped
+  effort/model, and anything the ticket description doesn't already carry. The ticket IS the spec —
+  don't paste the codebase into the prompt. Ask executors to report tersely (what changed, files/lines,
+  verification output, close confirmation) — data, not prose.
+- Parallelism costs tokens and orchestration overhead — a couple of parallel investigations or an
+  executor wave where sizes justify it, not a swarm for everything.
+
+## Scouting
+
+Scout before decomposing only when the surface is genuinely unfamiliar AND large: one or two
+read-only explorers, each on a distinct subsystem or open question, spawned together. A scout returns
+**compressed findings** — a pointer list or short summary (~1–2k tokens), never its reading
+transcript. The output feeds your ticket boundaries — guessing boundaries on a big unknown codebase
+produces tickets that collide.
+For a codebase you already know, or a task whose files you can name, skip the scout and just read the
+files. A substantive investigation (root-cause hunt, spike) is different from a scout: it gets a
+ticket, and its findings get commented back (see the main skill).
+
+## Workflows (opt-in — you propose, the user approves)
+
+The default parallelizer is named-subagent fan-out — always available, turn-by-turn, supervised. A
+**WORKFLOW** (`agent()`/`parallel()`/`pipeline()`) is the heavier tool for a larger, repeatable, or
+deterministic run: results stay in script variables, only the final output returns.
+
+- **Sizing** (by the story's complexity): small <5 · medium <15 · large <50, within the runtime cap
+  of 16 concurrent / 1000 total per run.
+- **Gated**: you don't launch one on your own — the user opts in (an "ultracode" prompt, or an
+  explicit ask). But you usually judge better than the user when one would genuinely help, so **when
+  it would, SUGGEST it** via `AskUserQuestion`: why it fits, the rough scale, the token cost. Raising
+  the option is how the opt-in happens; staying silent when a workflow would clearly help is the
+  mistake.
+- Typical fits: a wave of 6+ same-shaped executor tickets, a repeatable migrate/verify sweep, a
+  find→verify review structure.
+
+## Agent teams (CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS)
+
+With agent teams on (a **per-user** flag), parallel workers spawn as manageable teammates. The routing
+rules do not change, and one thing is critical: a teammate is a real sidequest executor **only if it
+has BOTH the correct agent type AND a unique `name`** — spawn the ticket's `sidequest-exec-<effort>`
+type with `model: <tier>` plus the name, exactly as you would a subagent. The failure to avoid:
+letting the "spawn a team" reflex launch default/generic teammates — a generic or unnamed teammate
+throws away the executor protocol (won't claim, won't verify, won't `done`), the tier routing, and
+addressability.
+
+Caveats:
+
+- A teammate may **inherit the lead's reasoning effort** instead of the effort the agent name implies.
+  Spawn the correctly-named executor regardless — the claim's `--effort` check still enforces the
+  right tier took the ticket. If it matters, also state the effort in the spawn prompt.
+- **Model does not inherit** — always pass `model: <tier>` explicitly.
+- The flag is per-user, so the identical spawn must also work as a plain subagent when it's off (it
+  does — never depend on teams being on).
+- Ticket execution is focused claim→do→verify→report work: the subagent sweet spot. Teams shine for
+  research/debate/review; if you're spawning teammates anyway, they must still be `sidequest-exec`
+  executors.
+
+## Unattended draining (`sidequest work`)
+
+Interactive fan-out through the `sidequest-exec-*` agents is the default — it keeps the effort axis
+and stays in your session. When the user wants the board worked **without** a live session ("just
+drain the backlog"), `sidequest work` spawns one headless `claude -p` run per ready ticket at its
+derived tier, wave by wave, until the board clears. Suggest it for the "work it while I'm away" ask;
+`sidequest work --dry-run` shows the plan first. Headless runs can't pin reasoning effort (that's
+agent-frontmatter only), so they carry the ticket's **model** at that model's default effort — which
+is why it's the overflow/unattended path, not a replacement for interactive effort-pinned execution.
+It's safe beside anything else (claiming stays atomic).

--- a/plugins/sidequest/skills/sidequest/references/routing-details.md
+++ b/plugins/sidequest/skills/sidequest/references/routing-details.md
@@ -1,0 +1,56 @@
+# Routing details: the ladder, bias, the effort grid
+
+Read this when you need to explain or debug routing — which score lands on which rung, why a rung is
+missing, what the bias slider does. Day-to-day you don't: every `list`/`ready` read stamps each ticket
+with its derived `model`/`effort`, and those stamps are the routing.
+
+## The capability ladder
+
+sidequest maps complexity scores onto **one capability-ranked ladder** of model×effort rungs built
+from the tiers the user enabled in the model picker (dashboard gear → Available models). Key
+properties:
+
+- **A single merged sequence, not per-tier bands.** Tiers overlap and cross over: `sonnet·xhigh`
+  outranks `opus·low` — capability orders the rungs, not tier. Adjacent scores may share a rung.
+- **Max effort is held out of the normal spread**: only complexity 10 on the top enabled tier gets
+  `·max` (and 9 only at bias +5) — deliberately rare, per Anthropic's guidance to use max effort
+  "sparingly for the hardest tasks".
+- **Live derivation**: toggling a tier or effort instantly re-routes every open ticket. Nothing is
+  stored on the ticket except the score; model/effort are stamped at read time.
+- **Effort exclusion is per model×effort pair**, not global — `opus·medium` can be off while
+  `sonnet·medium` stays on. An excluded pair never appears in the ladder.
+- `sidequest models` prints the current ladder; `--json` gives `routing` (the master switch), the
+  enabled grid, and the score→rung map.
+
+Tickets show `⚙C<score>→tier·effort` on their cards and in `list`/`ready`.
+
+## Bias (the user's dial, not yours)
+
+`sidequest bias <n>` (or the dashboard slider): `-5` Frugal … `0` neutral … `+5` Generous. Bias
+gamma-curves the score→rung map — it tunes HOW eagerly scores escalate to pricier rungs, never what
+you score. You always score complexity honestly against the absolute anchored scale in the main
+skill. Extremes stay invariant: complexity 1 always hits the cheapest rung and 10 the top rung at any
+bias.
+
+## Worked example
+
+Main session = fable, haiku disabled; ticket `SQ-12 ⚙C3→sonnet·max` (an odd ladder — only two tiers
+enabled — but it's what the stamps say):
+
+```
+Agent(subagent_type: "sidequest-exec-max", model: "sonnet", name: "exec-sq12",
+      prompt: claim SQ-12 → fix → verify → done)
+```
+
+The user re-enables haiku later → the same open ticket re-reads as `C3→sonnet·low` or lower — which is
+why you always spawn from a **fresh** `ready`/`list --json --brief` read for the wave, never a stale
+one. The executor claims with `--effort <its baked level>` and the board refuses a mismatch, so a
+stale spawn just bounces (a wasted round-trip, not a wrong-tier execution).
+
+## Re-scoring
+
+```bash
+sidequest update SQ-8 --complexity 5 --why "wider than scored: it also rewires the reader path"
+```
+
+A changed score must arrive with a fresh `--why`; an unmotivated re-score is rejected.

--- a/plugins/sidequest/test/_helpers.js
+++ b/plugins/sidequest/test/_helpers.js
@@ -1,0 +1,42 @@
+'use strict';
+// Shared harnesses for the sidequest test files, so each new file stops
+// hand-rolling its own spawn/call helpers (brief.test.js was about to be the
+// fourth copy of runCli/cliJson and the second of callTool). Named with a
+// leading underscore so `node --test` globbing never treats it as a suite.
+const assert = require('node:assert');
+const { spawnSync } = require('child_process');
+
+// A CLI runner bound to a bin path and env overrides.
+function makeCliRunner(bin, envOverrides) {
+  function runCli(args) {
+    const env = Object.assign({}, process.env, envOverrides || {});
+    const res = spawnSync(process.execPath, [bin, ...args], { encoding: 'utf8', env });
+    return { status: res.status, stdout: res.stdout || '', stderr: res.stderr || '' };
+  }
+  function cliJson(args) {
+    const res = runCli(args);
+    assert.strictEqual(res.status, 0, `expected success: ${args.join(' ')}\n${res.stderr}${res.stdout}`);
+    return JSON.parse(res.stdout);
+  }
+  return { runCli, cliJson };
+}
+
+// An MCP tool caller bound to an already-required lib/mcp.js module. The env
+// vars (SIDEQUEST_HOME, CLAUDE_PROJECT_DIR) must be set BEFORE that require —
+// which is why this takes the module rather than requiring it itself.
+function makeMcpCaller(mcp) {
+  let idc = 0;
+  function callToolRaw(name, args) {
+    const resp = mcp.handleRequest({ jsonrpc: '2.0', id: ++idc, method: 'tools/call', params: { name, arguments: args || {} } });
+    return resp && resp.result;
+  }
+  function callTool(name, args) {
+    const result = callToolRaw(name, args);
+    assert.ok(result, `tool ${name} returned a result`);
+    assert.ok(!result.isError, `tool ${name} errored: ${result.content && result.content[0] && result.content[0].text}`);
+    return JSON.parse(result.content[0].text);
+  }
+  return { callTool, callToolRaw };
+}
+
+module.exports = { makeCliRunner, makeMcpCaller };

--- a/plugins/sidequest/test/brief.test.js
+++ b/plugins/sidequest/test/brief.test.js
@@ -1,0 +1,134 @@
+'use strict';
+/**
+ * Tests for the compact orchestration read: `--brief` on the CLI (list/ready)
+ * and `brief: true` on the MCP list/ready tools.
+ *
+ * Why it exists (2026-07 token diet): a full ticket carries its whole
+ * description and comment thread. An orchestrator re-reads the board before
+ * every wave, so those bodies were paid for on every read without being
+ * needed. The executor working the ticket reads the full record instead; the
+ * brief shape is everything routing/batching needs and nothing else.
+ *
+ * Both transports serve store.listPayload/readyPayload, so the shapes cannot
+ * drift: --brief implies --json on the CLI, and `waves` is ALWAYS arrays of
+ * refs (brief or not, CLI or MCP).
+ *
+ * Run: node --test plugins/sidequest/test/brief.test.js
+ */
+const test = require('node:test');
+const assert = require('node:assert');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+const { makeCliRunner, makeMcpCaller } = require('./_helpers.js');
+
+const SIDEQUEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'sq-brief-test-'));
+process.env.SIDEQUEST_HOME = SIDEQUEST_HOME;
+const PROJ = path.join(os.tmpdir(), 'sq-brief-fixtures', 'board');
+process.env.CLAUDE_PROJECT_DIR = PROJ;
+
+const mcp = require('../lib/mcp.js');
+
+const BIN = path.join(__dirname, '..', 'bin', 'sidequest.js');
+const { runCli, cliJson } = makeCliRunner(BIN, { SIDEQUEST_HOME, CLAUDE_PROJECT_DIR: PROJ });
+const { callTool } = makeMcpCaller(mcp);
+
+// The exact key set of a brief ticket. A new field is a deliberate decision,
+// not drift: every key is paid for on every orchestration read, and the
+// MCP/skill docs enumerate this list.
+const BRIEF_KEYS = [
+  'ref', 'title', 'status', 'priority', 'complexity', 'model', 'effort',
+  'files', 'claim', 'blockedBy', 'comments', 'awaitingReply',
+].sort();
+
+// Seed once: one ticket with a fat body + a comment, one plain.
+let refA;
+test('seed fixtures', () => {
+  const a = cliJson(['add', '-t', 'brief fixture A', '-d', 'a long developer-to-developer spec body that brief reads must not carry', '--file', 'lib/a.js', '--complexity', '3', '--why', 'a routine single-file fixture change for the brief-read tests', '--json']);
+  refA = a.ticket.ref;
+  const c = runCli(['comment', refA, '-m', 'a thread entry that brief reads must count, not carry']);
+  assert.strictEqual(c.status, 0, c.stderr);
+  // A second, file-disjoint ticket so `ready` has a real multi-ticket set.
+  cliJson(['add', '-t', 'brief fixture B', '--file', 'lib/b.js', '--complexity', '5', '--why', 'an everyday one-area fixture change for the brief-read tests', '--json']);
+});
+
+test('CLI: list --json --brief returns the compact shape only', () => {
+  const out = cliJson(['list', '--json', '--brief']);
+  assert.ok(out.tickets.length >= 2, 'both fixtures listed');
+  for (const t of out.tickets) {
+    assert.deepStrictEqual(Object.keys(t).sort(), BRIEF_KEYS, 'exactly the brief keys, no bodies, no ids');
+  }
+  const a = out.tickets.find((t) => t.ref === refA);
+  assert.ok(a.model && a.effort !== undefined, 'derived routing is stamped on the brief read');
+  assert.strictEqual(a.comments, 1, 'thread is a count, not the entries');
+});
+
+test('CLI: --brief implies --json (never silently a no-op)', () => {
+  const out = cliJson(['list', '--brief']);
+  assert.ok(Array.isArray(out.tickets), '--brief alone must emit the JSON payload');
+  assert.deepStrictEqual(Object.keys(out.tickets[0]).sort(), BRIEF_KEYS);
+  const ready = cliJson(['ready', '--brief']);
+  assert.ok(Array.isArray(ready.tickets) && Array.isArray(ready.waves), 'ready --brief too');
+});
+
+test('CLI: list --json (no --brief) still returns full tickets', () => {
+  const out = cliJson(['list', '--json']);
+  const a = out.tickets.find((t) => t.ref === refA);
+  assert.ok(a.description.includes('long developer-to-developer'), 'full read keeps the body');
+  assert.ok(Array.isArray(a.comments), 'full read keeps the thread');
+});
+
+test('CLI: ready --json --brief returns compact tickets + ref waves', () => {
+  const out = cliJson(['ready', '--json', '--brief']);
+  assert.ok(out.tickets.length >= 2, 'both fixtures are ready');
+  for (const t of out.tickets) {
+    assert.deepStrictEqual(Object.keys(t).sort(), BRIEF_KEYS);
+    assert.deepStrictEqual(t.blockedBy, [], 'ready tickets are unblocked by construction');
+  }
+  for (const wave of out.waves) {
+    for (const r of wave) assert.match(r, /^SQ-\d+$/, 'waves are refs');
+  }
+});
+
+test('MCP: list/ready with brief:true return the compact shape', () => {
+  const list = callTool('list', { brief: true });
+  for (const t of list.tickets) {
+    assert.deepStrictEqual(Object.keys(t).sort(), BRIEF_KEYS);
+  }
+  const ready = callTool('ready', { brief: true });
+  for (const t of ready.tickets) {
+    assert.deepStrictEqual(Object.keys(t).sort(), BRIEF_KEYS);
+  }
+  for (const wave of ready.waves) {
+    for (const r of wave) assert.match(String(r), /^SQ-\d+$/, 'brief waves are refs');
+  }
+});
+
+test('MCP: waves are refs with and without brief (one shape per field)', () => {
+  const full = callTool('ready', {});
+  for (const wave of full.waves) {
+    for (const r of wave) {
+      assert.strictEqual(typeof r, 'string', 'non-brief waves must also be refs, not ticket objects');
+      assert.match(r, /^SQ-\d+$/);
+    }
+  }
+  assert.ok(full.tickets.some((t) => typeof t.description === 'string'), 'full tickets still ride in tickets');
+});
+
+test('MCP: list without brief still returns full tickets', () => {
+  const list = callTool('list', {});
+  const a = list.tickets.find((t) => t.ref === refA);
+  assert.ok(a.description.includes('long developer-to-developer'), 'full read keeps the body');
+});
+
+test('brief blockedBy resolves open blockers (in-memory index, correct field name)', () => {
+  const c = cliJson(['add', '-t', 'blocked fixture C', '--file', 'lib/c.js', '--complexity', '2', '--why', 'a mechanical fixture change that depends on fixture A landing first', '--json']);
+  const refC = c.ticket.ref;
+  const link = runCli(['link', refC, 'depends-on', refA]);
+  assert.strictEqual(link.status, 0, link.stderr);
+  const out = cliJson(['list', '--brief']);
+  const briefC = out.tickets.find((t) => t.ref === refC);
+  assert.deepStrictEqual(briefC.blockedBy, [refA], 'blockedBy carries the open blocker ref');
+  const ready = cliJson(['ready', '--brief']);
+  assert.ok(!ready.tickets.some((t) => t.ref === refC), 'a blocked ticket is not ready');
+});

--- a/plugins/sidequest/test/hooks.test.js
+++ b/plugins/sidequest/test/hooks.test.js
@@ -1,19 +1,25 @@
 'use strict';
 /**
- * Tests for the UserPromptSubmit / SessionStart hooks (SQ-105 / SQ-106 / SQ-109).
+ * Tests for the UserPromptSubmit / SessionStart hooks.
  *
- * These lock in three fixes that came out of the "agents ignore the fan-out
- * guidance" investigation (contractify session 634fecde):
- *   - SQ-105: the SessionStart nudge now carries fan-out guidance at all.
- *   - SQ-106: the plan+fan-out discipline is no longer SUPPRESSED when a prompt
- *     trips a capture or board-management marker — those blocks used to
- *     process.exit early, dropping the guidance exactly on the action prompts
- *     that kick off real work. Both blocks now carry the core-discipline footer.
- *     Over-broad capture markers ('needs to' / 'missing' / "won't") were pruned
- *     so ordinary task descriptions stop tripping capture.
- *   - SQ-109: the fan-out line is concrete and trigger-based ("read ~4+ files"
- *     -> spawn an Explore / code-explorer scout), not the abstract "lean
- *     parallel over serial" that got ignored mid-execution even when present.
+ * These lock in the 2026-07 token diet. Hook output is UNCACHED context on the
+ * turn it fires and then sits in the transcript for the rest of the session, so
+ * the per-prompt hook was the plugin's most expensive surface: it used to emit
+ * a ~600-token doctrine block on EVERY prompt ("~95% off the main thread",
+ * "scout before reading ~4+ files"), which is exactly the over-orchestration
+ * users then saw. The regime now:
+ *
+ *   - The no-marker standing reminder is ONE short line. The full doctrine
+ *     lives in SessionStart (which re-fires on compact/resume) and the skill.
+ *   - SessionStart carries the execution economy: expensive orchestrator,
+ *     cheap executors — route work DOWN to each ticket's stamped tier as
+ *     SHORT, bounded runs that bounce back fast; batch small same-tier tickets
+ *     into one executor; inline only trivial one-steps.
+ *   - Every block has a byte budget asserted here, so the blocks can't quietly
+ *     grow back.
+ *   - Earlier fixes stay locked: over-broad capture markers stay pruned
+ *     (SQ-106), and capture/mgmt blocks keep a (now one-line) discipline
+ *     footer so an action prompt doesn't lose it entirely.
  *
  * The hooks are Node scripts that read a JSON payload on stdin and print a
  * hookSpecificOutput envelope on stdout, so we exercise them as subprocesses
@@ -31,6 +37,17 @@ const HOOKS = path.join(__dirname, '..', 'hooks');
 const CAPTURE = path.join(HOOKS, 'capture-nudge.js');
 const SESSION = path.join(HOOKS, 'session-start.js');
 
+// Byte budgets (chars ≈ tokens × ~4). CLI paths inside the blocks vary by
+// machine, so these have headroom — the point is catching a doctrine block
+// growing back to its old ~2.5KB size, not byte-exact accounting.
+const BUDGET = {
+  standing: 400, // the every-prompt line — keep this one genuinely tiny
+  session: 1900, // once per session start
+  compact: 600, // once per compact/resume
+  capture: 1500, // marker-gated
+  mgmt: 1600, // marker-gated
+};
+
 // Run a hook with the given stdin payload and return the injected
 // additionalContext string (or '' when the hook stays silent).
 function runHook(script, payload) {
@@ -45,24 +62,31 @@ function runHook(script, payload) {
 
 const capture = (prompt) => runHook(CAPTURE, { prompt });
 
-// Markers of the concrete, trigger-based fan-out guidance (SQ-109). We assert
-// on the trigger phrasing and the NAMED tool, since the whole finding was that
-// abstract wording gets ignored — the test should fail if someone softens it
-// back to vibes.
-const CONCRETE_TRIGGER = 'read ~4+ files';
-const NAMED_SCOUT = 'Explore / code-explorer';
-const FOOTER_MARK = 'sidequest discipline';
+const FOOTER_MARK = '— sidequest:';
+
+// Phrases from the retired heavy doctrine that must NOT come back to any block.
+const RETIRED = ['95%', 'read ~4+ files', 'AskUserQuestion', 'coreDiscipline'];
+
+function assertNoRetiredDoctrine(ctx, where) {
+  for (const phrase of RETIRED) {
+    assert.ok(!ctx.includes(phrase), `${where} must not carry retired doctrine ("${phrase}")`);
+  }
+}
 
 /* ------------------------------------------------------------------ *
- *  SessionStart (SQ-105 + SQ-109)
+ *  SessionStart — the one full doctrine block
  * ------------------------------------------------------------------ */
 
-test('session-start: carries the concrete, named-tool fan-out guidance', () => {
+test('session-start: carries the route-down + tight-loop doctrine', () => {
   const ctx = runHook(SESSION, { session_id: 'test' });
   assert.match(ctx, /sidequest \(active\)/);
-  assert.ok(ctx.includes('FAN OUT'), 'SessionStart should mention FAN OUT');
-  assert.ok(ctx.includes(CONCRETE_TRIGGER), 'fan-out line must be trigger-based, not abstract');
-  assert.ok(ctx.includes(NAMED_SCOUT), 'fan-out line must name the scout subagent');
+  assert.ok(ctx.includes('ATOMIC'), 'must demand atomic tickets (stuck executors come from oversized scope)');
+  assert.ok(ctx.includes('DOWN'), 'must say execution routes down to the stamped tier');
+  assert.ok(ctx.includes('sidequest-exec-'), 'must name the routed executor');
+  assert.ok(ctx.includes('SHORT'), 'must demand short, bounded executor runs');
+  assert.ok(ctx.includes('bounce back'), 'must tell executors to bounce back, not wander');
+  assert.ok(ctx.includes('ONE executor'), 'must carry the batch-small-tickets rule');
+  assert.ok(ctx.includes('trivial one-step'), 'inline is only for trivial one-steps');
 });
 
 test('session-start: says sidequest coexists with an external tracker (Jira)', () => {
@@ -71,21 +95,21 @@ test('session-start: says sidequest coexists with an external tracker (Jira)', (
   assert.ok(ctx.includes('Jira'), 'must name Jira so the "already tracked" reflex is countered');
 });
 
-test('session-start: stresses routed-subagent execution + the model-routing why', () => {
+test('session-start: stays inside its byte budget and off the retired doctrine', () => {
   const ctx = runHook(SESSION, { session_id: 'test' });
-  assert.ok(ctx.includes('routed subagent'), 'must push routed-subagent execution');
-  assert.ok(ctx.includes('best model'), 'must give the model-routing reason');
-  assert.ok(ctx.includes('95%'), 'must state the ~95%-in-a-subagent bar');
-  assert.ok(ctx.includes('subagent workflows'), 'must frame execution as subagent workflows');
-  assert.ok(ctx.includes('teams of sub-agents'), 'must frame execution as teams of sub-agents');
+  assert.ok(
+    ctx.length <= BUDGET.session,
+    `session block is ${ctx.length} chars — budget is ${BUDGET.session}; trim it, don't raise the budget`
+  );
+  assertNoRetiredDoctrine(ctx, 'session-start');
 });
 
 test('session-start: source=compact gets the terse re-grounding block, not the full nudge', () => {
   const ctx = runHook(SESSION, { session_id: 't', source: 'compact' });
   assert.match(ctx, /sidequest \(active — context restored\)/);
   assert.ok(ctx.includes('list --status doing'), 'must tell Claude to re-check in-flight claims');
-  assert.ok(ctx.includes('context'), 'must mention context being restored/compacted');
   assert.ok(!ctx.includes('external tracker'), 'must NOT be the full block on compact');
+  assert.ok(ctx.length <= BUDGET.compact, `compact block is ${ctx.length} chars — budget is ${BUDGET.compact}`);
 });
 
 test('session-start: source=startup still gets the full block', () => {
@@ -103,47 +127,67 @@ test('session-start: SIDEQUEST_NUDGE=off silences it', () => {
 });
 
 /* ------------------------------------------------------------------ *
- *  Standing reminder — the no-marker path (SQ-109)
+ *  Standing reminder — the no-marker path is ONE short line
  * ------------------------------------------------------------------ */
 
-test('standing reminder: plain task prompt gets the concrete fan-out trigger', () => {
+test('standing reminder: plain task prompt gets one short line, not a doctrine block', () => {
   const ctx = capture('add a new export format to the reporter');
   assert.match(ctx, /sidequest \(active\)/);
-  assert.ok(ctx.includes(CONCRETE_TRIGGER), 'standing reminder must carry the concrete trigger');
-  assert.ok(ctx.includes(NAMED_SCOUT), 'standing reminder must name the scout subagent');
+  assert.ok(ctx.includes('tickets'), 'must still point at the board');
+  assert.ok(
+    ctx.length <= BUDGET.standing,
+    `standing reminder is ${ctx.length} chars — budget is ${BUDGET.standing}; this fires EVERY prompt`
+  );
+  assertNoRetiredDoctrine(ctx, 'standing reminder');
 });
 
-test('standing reminder: says sidequest coexists with an external tracker (Jira)', () => {
-  const ctx = capture('add a new export format to the reporter');
-  assert.ok(ctx.includes('external tracker'), 'must address the external-tracker case');
-  assert.ok(ctx.includes('Jira'), 'must name Jira so the "already tracked" reflex is countered');
-});
-
-test('standing reminder: stresses routed-subagent execution (~95%, not the main thread)', () => {
-  const ctx = capture('add a new export format to the reporter');
-  assert.ok(ctx.includes('EXECUTE via a routed subagent'), 'must carry the EXECUTE bullet');
-  assert.ok(ctx.includes('95%'), 'must state the ~95%-in-a-subagent bar');
-  assert.ok(ctx.includes('sidequest-exec-'), 'must name the executor subagent to spawn');
-  assert.ok(ctx.includes('subagent workflows'), 'must frame execution as subagent workflows');
-  assert.ok(ctx.includes('teams of sub-agents'), 'must frame execution as teams of sub-agents');
+test('standing reminder: SIDEQUEST_NUDGE=off silences it (marker blocks still fire)', () => {
+  const env = { ...process.env, SIDEQUEST_NUDGE: 'off' };
+  const plain = execFileSync(process.execPath, [CAPTURE], {
+    input: JSON.stringify({ prompt: 'add a new export format' }),
+    encoding: 'utf8',
+    env,
+  });
+  assert.strictEqual(plain.trim(), '', 'no-marker path should emit nothing when nudge is off');
+  const defect = execFileSync(process.execPath, [CAPTURE], {
+    input: JSON.stringify({ prompt: 'the login form is broken' }),
+    encoding: 'utf8',
+    env,
+  });
+  assert.ok(defect.includes('capture the side quest'), 'capture block must still fire when nudge is off');
 });
 
 /* ------------------------------------------------------------------ *
- *  Discipline is not suppressed by capture / mgmt branches (SQ-106)
+ *  Capture block
  * ------------------------------------------------------------------ */
 
-test('capture block still carries the core-discipline footer', () => {
+test('capture block: fires on a defect prompt, carries the filing command + footer, inside budget', () => {
   const ctx = capture('the login form is broken');
   assert.ok(ctx.includes('capture the side quest'), 'a defect prompt should hit the capture block');
-  assert.ok(ctx.includes(FOOTER_MARK), 'capture block must still carry the plan+fan-out footer');
-  assert.ok(ctx.includes(CONCRETE_TRIGGER), 'footer must carry the concrete fan-out trigger');
+  assert.ok(ctx.includes('ticket-filer'), 'must prefer the background ticket-filer');
+  assert.ok(ctx.includes('--complexity'), 'must show the required complexity flag');
+  assert.ok(ctx.includes(FOOTER_MARK), 'must keep the one-line discipline footer');
+  assert.ok(ctx.length <= BUDGET.capture, `capture block is ${ctx.length} chars — budget is ${BUDGET.capture}`);
+  assertNoRetiredDoctrine(ctx, 'capture block');
 });
 
-test('board-management block still carries the core-discipline footer', () => {
+/* ------------------------------------------------------------------ *
+ *  Board-management block
+ * ------------------------------------------------------------------ */
+
+test('board-management block: fires on a dashboard prompt, carries claim discipline, inside budget', () => {
   const ctx = capture('show me the dashboard');
   assert.ok(ctx.includes('board control'), 'a dashboard prompt should hit the mgmt block');
-  assert.ok(ctx.includes(FOOTER_MARK), 'mgmt block must still carry the plan+fan-out footer');
-  assert.ok(ctx.includes(CONCRETE_TRIGGER), 'footer must carry the concrete fan-out trigger');
+  assert.ok(ctx.includes('claim'), 'must carry the claim-first rule');
+  assert.ok(ctx.includes('mcp__plugin_sidequest_board__'), 'must point at the MCP tools first');
+  assert.ok(ctx.includes(FOOTER_MARK), 'must keep the one-line discipline footer');
+  assert.ok(ctx.length <= BUDGET.mgmt, `mgmt block is ${ctx.length} chars — budget is ${BUDGET.mgmt}`);
+  assertNoRetiredDoctrine(ctx, 'mgmt block');
+});
+
+test('an SQ-ref prompt routes to the board-management block', () => {
+  const ctx = capture('close SQ-3');
+  assert.ok(ctx.includes('board control'), 'an SQ-\\d+ ref should hit the mgmt block');
 });
 
 /* ------------------------------------------------------------------ *
@@ -168,13 +212,4 @@ test('genuine defect words still trip capture', () => {
   // 'crash' is deliberately kept — a real "X crashed" report should still file.
   assert.ok(capture('the exporter crashes on empty input').includes('capture the side quest'));
   assert.ok(capture('oh and the contact form is broken').includes('capture the side quest'));
-});
-
-/* ------------------------------------------------------------------ *
- *  Board-management routing still works (regression guard)
- * ------------------------------------------------------------------ */
-
-test('an SQ-ref prompt routes to the board-management block', () => {
-  const ctx = capture('close SQ-3');
-  assert.ok(ctx.includes('board control'), 'an SQ-\\d+ ref should hit the mgmt block');
 });

--- a/plugins/sidequest/test/mcp.test.js
+++ b/plugins/sidequest/test/mcp.test.js
@@ -1,0 +1,148 @@
+'use strict';
+/**
+ * Tests for the MCP tool layer (SQ-152): the JSON-RPC handler in lib/mcp.js and
+ * the stdio server in bin/sidequest-mcp.js.
+ *
+ * Two levels:
+ *   - handleRequest() unit tests (fast, in-process) for the protocol handshake
+ *     and the tool round-trips over the same store the CLI uses.
+ *   - one child_process integration test that drives the real stdio server with
+ *     newline-delimited JSON-RPC, to prove the transport frames correctly.
+ *
+ * Run: node --test plugins/sidequest/test/mcp.test.js
+ */
+const test = require('node:test');
+const assert = require('node:assert');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+
+const SIDEQUEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'sq-mcp-test-'));
+process.env.SIDEQUEST_HOME = SIDEQUEST_HOME;
+const PROJ = path.join(os.tmpdir(), 'sq-mcp-fixtures', 'board');
+process.env.CLAUDE_PROJECT_DIR = PROJ;
+
+const mcp = require('../lib/mcp.js');
+
+// Call a tool through the JSON-RPC surface and return the parsed result object
+// (the text content decoded back to JSON), asserting it wasn't an error.
+let idc = 0;
+function callTool(name, args) {
+  const resp = mcp.handleRequest({ jsonrpc: '2.0', id: ++idc, method: 'tools/call', params: { name, arguments: args || {} } });
+  assert.ok(resp && resp.result, `tool ${name} returned a result`);
+  assert.ok(!resp.result.isError, `tool ${name} errored: ${resp.result.content && resp.result.content[0] && resp.result.content[0].text}`);
+  return JSON.parse(resp.result.content[0].text);
+}
+function callToolRaw(name, args) {
+  const resp = mcp.handleRequest({ jsonrpc: '2.0', id: ++idc, method: 'tools/call', params: { name, arguments: args || {} } });
+  return resp.result;
+}
+
+test('initialize returns a protocol version, tools capability, and serverInfo', () => {
+  const resp = mcp.handleRequest({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18' } });
+  assert.strictEqual(resp.result.protocolVersion, '2025-06-18', 'echoes the client-requested version');
+  assert.ok(resp.result.capabilities.tools, 'advertises tools');
+  assert.strictEqual(resp.result.serverInfo.name, 'sidequest');
+});
+
+test('notifications/initialized takes no response', () => {
+  const resp = mcp.handleRequest({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  assert.strictEqual(resp, null);
+});
+
+test('tools/list advertises the board tools with input schemas', () => {
+  const resp = mcp.handleRequest({ jsonrpc: '2.0', id: 2, method: 'tools/list' });
+  const names = resp.result.tools.map((t) => t.name);
+  for (const expected of ['list', 'ready', 'add', 'claim', 'next', 'done', 'release', 'comment', 'ask', 'link', 'models']) {
+    assert.ok(names.includes(expected), `exposes ${expected}`);
+  }
+  for (const t of resp.result.tools) {
+    assert.strictEqual(t.inputSchema.type, 'object', `${t.name} has an object input schema`);
+  }
+});
+
+test('an unknown method is a JSON-RPC method-not-found error', () => {
+  const resp = mcp.handleRequest({ jsonrpc: '2.0', id: 3, method: 'does/not/exist' });
+  assert.ok(resp.error, 'returns an error object');
+  assert.strictEqual(resp.error.code, -32601);
+});
+
+test('add enforces complexity + why and rejects direct model/effort', () => {
+  // Missing complexity/why -> isError.
+  assert.ok(callToolRaw('add', { title: 'no score' }).isError, 'missing complexity/why errors');
+  assert.ok(callToolRaw('add', { title: 'bad', complexity: 3, why: 'too short' }).isError, 'a thin why errors');
+  assert.ok(callToolRaw('add', { title: 'direct', complexity: 3, why: 'x'.repeat(25), model: 'opus' }).isError, 'a direct model errors');
+
+  const out = callTool('add', { title: 'MCP add works', complexity: 3, why: 'a real motivation referencing the actual single-file change' });
+  assert.strictEqual(out.ok, true);
+  assert.match(out.ticket.ref, /^SQ-\d+$/);
+  assert.strictEqual(out.ticket.complexity, 3);
+  assert.ok(out.ticket.model, 'routing is derived and stamped');
+});
+
+test('claim -> comment -> done round-trips over the same store, tagged source mcp', () => {
+  const added = callTool('add', { title: 'work me', complexity: 2, why: 'a mechanical change to exercise the claim/done path over MCP' });
+  const ref = added.ticket.ref;
+
+  const claim = callTool('claim', { ref, by: 'mcp-worker-1' });
+  assert.strictEqual(claim.ok, true);
+  assert.strictEqual(claim.ticket.status, 'doing');
+
+  const note = callTool('comment', { ref, body: 'progress note from an MCP tool call' });
+  assert.strictEqual(note.ok, true);
+  assert.strictEqual(note.comment.source, 'mcp', 'MCP actions are tagged as background (not dashboard)');
+
+  const done = callTool('done', { ref, by: 'mcp-worker-1', model: 'sonnet', effort: 'high' });
+  assert.strictEqual(done.ok, true);
+  assert.strictEqual(done.ticket.status, 'done');
+});
+
+test('claim requires a worker id (no shared-identity default)', () => {
+  const added = callTool('add', { title: 'needs by', complexity: 2, why: 'confirm the atomic-claim identity guard is enforced over MCP' });
+  const res = callToolRaw('claim', { ref: added.ticket.ref });
+  assert.ok(res.isError, 'a claim without by is refused');
+  assert.match(res.content[0].text, /by.*required/i);
+});
+
+test('claim with a mismatched effort is refused (drift guard mirrors the CLI)', () => {
+  const store = require('../lib/store.js');
+  store.setModelPrefs({ routing: true });
+  const added = callTool('add', { title: 'effort guard', complexity: 5, why: 'seed a ticket whose derived effort the MCP claim guard checks' });
+  const ref = added.ticket.ref;
+  const derived = added.ticket.effort;
+  assert.ok(derived, 'routing on -> a derived effort');
+  const wrong = store.VALID_EFFORTS.find((e) => e !== derived);
+  const res = callTool('claim', { ref, by: 'mcp-w', effort: wrong });
+  assert.strictEqual(res.ok, false);
+  assert.strictEqual(res.reason, 'effort_mismatch');
+  assert.strictEqual(res.derivedEffort, derived);
+  // The ticket must stay unclaimed after a refused claim.
+  const after = callTool('list', {});
+  const t = after.tickets.find((x) => x.ref === ref);
+  assert.strictEqual(t.status, 'todo');
+  assert.strictEqual(t.claim, null);
+});
+
+test('the real stdio server frames newline-delimited JSON-RPC', () => {
+  const BIN = path.join(__dirname, '..', 'bin', 'sidequest-mcp.js');
+  const requests = [
+    { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18' } },
+    { jsonrpc: '2.0', method: 'notifications/initialized' },
+    { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+    { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'projects', arguments: {} } },
+  ];
+  const input = requests.map((r) => JSON.stringify(r)).join('\n') + '\n';
+  const env = Object.assign({}, process.env, { SIDEQUEST_HOME, CLAUDE_PROJECT_DIR: PROJ });
+  const res = spawnSync(process.execPath, [BIN], { input, encoding: 'utf8', env, timeout: 10000 });
+  const lines = (res.stdout || '').split('\n').filter((l) => l.trim());
+  const parsed = lines.map((l) => JSON.parse(l));
+  // Three responses (the notification produced none).
+  assert.strictEqual(parsed.length, 3, `expected 3 responses, got ${parsed.length}: ${res.stdout}`);
+  assert.strictEqual(parsed[0].id, 1);
+  assert.ok(parsed[0].result.serverInfo);
+  assert.strictEqual(parsed[1].id, 2);
+  assert.ok(Array.isArray(parsed[1].result.tools));
+  assert.strictEqual(parsed[2].id, 3);
+  assert.ok(!parsed[2].result.isError, 'projects tool call succeeded');
+});

--- a/plugins/sidequest/test/reconcile.test.js
+++ b/plugins/sidequest/test/reconcile.test.js
@@ -1,0 +1,133 @@
+'use strict';
+/**
+ * Tests for the session worker registry + reconcileSession (SQ-153).
+ *
+ * The claim TTL (default 60 min) frees a crashed worker's ticket eventually. The
+ * registry lets a SessionEnd / SubagentStop hook do it IMMEDIATELY, but safely:
+ * reconciling a session must release ONLY the claims taken under that exact
+ * session id, never a claim another live session holds, and never a finished
+ * ticket. These tests pin that safety.
+ *
+ * Run: node --test plugins/sidequest/test/reconcile.test.js
+ */
+const test = require('node:test');
+const assert = require('node:assert');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+
+const SIDEQUEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'sq-reconcile-test-'));
+process.env.SIDEQUEST_HOME = SIDEQUEST_HOME;
+
+const store = require('../lib/store.js');
+
+const { slug } = store.ensureProject(path.join(os.tmpdir(), 'sq-reconcile-fixtures', 'board'));
+
+function addTicket(title) {
+  return store.createTicket(slug, { title, complexity: 3, complexityWhy: 'fixture for reconcile tests, single mechanical change', source: 'cli' });
+}
+
+test('reconcileSession releases only the ending session\'s claims, and moves them back to todo', () => {
+  const a = addTicket('session A ticket');
+  const b = addTicket('session B ticket');
+
+  const ra = store.claimTicket(slug, a.ref, 'worker-a', { sessionId: 'sess-A' });
+  const rb = store.claimTicket(slug, b.ref, 'worker-b', { sessionId: 'sess-B' });
+  assert.strictEqual(ra.ok, true);
+  assert.strictEqual(rb.ok, true);
+  assert.strictEqual(store.getTicket(slug, a.ref).status, 'doing');
+  assert.strictEqual(store.getTicket(slug, b.ref).status, 'doing');
+
+  const res = store.reconcileSession('sess-A', { reason: 'session ended' });
+  assert.strictEqual(res.ok, true);
+  assert.deepStrictEqual(res.released, [a.ref], 'only A\'s ticket is released');
+
+  const at = store.getTicket(slug, a.ref);
+  assert.strictEqual(at.status, 'todo', 'A\'s ticket returns to todo');
+  assert.strictEqual(at.claim, null, 'A\'s claim is cleared');
+
+  const bt = store.getTicket(slug, b.ref);
+  assert.strictEqual(bt.status, 'doing', 'B\'s ticket is untouched');
+  assert.ok(bt.claim && bt.claim.by === 'worker-b', 'B\'s claim is intact');
+});
+
+test('reconcileSession leaves a note comment on each released ticket', () => {
+  const a = addTicket('to be auto-released');
+  store.claimTicket(slug, a.ref, 'worker-x', { sessionId: 'sess-note' });
+  store.reconcileSession('sess-note', { reason: 'subagent stopped' });
+  const t = store.getTicket(slug, a.ref);
+  const last = t.comments[t.comments.length - 1];
+  assert.ok(last, 'a comment was added');
+  assert.match(last.body, /Auto-released/i);
+  assert.match(last.body, /subagent stopped/i);
+});
+
+test('a completed ticket is never auto-released, even if still registered', () => {
+  const a = addTicket('finished before reconcile');
+  store.claimTicket(slug, a.ref, 'worker-done', { sessionId: 'sess-done' });
+  // Finish WITHOUT passing the sessionId (simulates a done that forgot to thread
+  // it) so the registry entry lingers — reconcile must still skip the done ticket.
+  store.completeTicket(slug, a.ref, 'worker-done', { model: 'sonnet', effort: 'high' });
+  assert.strictEqual(store.getTicket(slug, a.ref).status, 'done');
+
+  const res = store.reconcileSession('sess-done', { reason: 'session ended' });
+  assert.deepStrictEqual(res.released, [], 'a done ticket is not released');
+  assert.strictEqual(store.getTicket(slug, a.ref).status, 'done', 'still done');
+});
+
+test('reconcileSession is idempotent — a second call releases nothing', () => {
+  const a = addTicket('idempotency check');
+  store.claimTicket(slug, a.ref, 'worker-i', { sessionId: 'sess-idem' });
+  const first = store.reconcileSession('sess-idem', { reason: 'ended' });
+  assert.deepStrictEqual(first.released, [a.ref]);
+  const second = store.reconcileSession('sess-idem', { reason: 'ended' });
+  assert.deepStrictEqual(second.released, [], 'nothing left to release');
+});
+
+test('a claim re-taken by another session since is NOT released by the first session\'s reconcile', () => {
+  const a = addTicket('re-claimed in the interim');
+  store.claimTicket(slug, a.ref, 'worker-1', { sessionId: 'sess-1' });
+  // Session 2 force-steals it (as if the TTL lapsed or --force was used) and
+  // registers under its own session.
+  store.claimTicket(slug, a.ref, 'worker-2', { sessionId: 'sess-2', force: true });
+  assert.strictEqual(store.getTicket(slug, a.ref).claim.by, 'worker-2');
+
+  const res = store.reconcileSession('sess-1', { reason: 'session 1 ended' });
+  assert.deepStrictEqual(res.released, [], 'session 1 must not release a claim now held by session 2');
+  assert.strictEqual(store.getTicket(slug, a.ref).claim.by, 'worker-2', 'session 2\'s live claim stands');
+});
+
+test('unregisterClaim drops a claim so a later reconcile ignores it', () => {
+  const a = addTicket('unregistered before reconcile');
+  store.claimTicket(slug, a.ref, 'worker-u', { sessionId: 'sess-unreg' });
+  store.unregisterClaim('sess-unreg', slug, a.id);
+  // The ticket is still 'doing' (unregister doesn't touch the ticket), but the
+  // registry no longer attributes it to the session, so reconcile is a no-op.
+  const res = store.reconcileSession('sess-unreg', { reason: 'ended' });
+  assert.deepStrictEqual(res.released, []);
+  assert.strictEqual(store.getTicket(slug, a.ref).status, 'doing', 'ticket unchanged by a no-op reconcile');
+});
+
+test('reconciling an unknown session is a harmless no-op', () => {
+  const res = store.reconcileSession('nope-not-a-session', { reason: 'ended' });
+  assert.strictEqual(res.ok, true);
+  assert.deepStrictEqual(res.released, []);
+});
+
+// The TOCTOU guard: releaseTicket must refuse a DONE ticket outright (the fresh
+// locked read is authoritative), so a reconcile racing behind a completeTicket
+// can never yank finished work back to todo. completeTicket clears the claim, so
+// without this guard the empty-claim ownership check would pass vacuously.
+test('releaseTicket refuses a done ticket — a reconcile cannot un-complete finished work', () => {
+  const a = addTicket('finished, then a stale release arrives');
+  store.claimTicket(slug, a.ref, 'worker-r', { sessionId: 'sess-race' });
+  store.completeTicket(slug, a.ref, 'worker-r', { model: 'sonnet', effort: 'high' });
+  assert.strictEqual(store.getTicket(slug, a.ref).status, 'done');
+
+  // The exact call reconcileSession would make against a ticket it believed was
+  // still 'doing' but which finished in the meantime.
+  const res = store.releaseTicket(slug, a.ref, 'worker-r', { status: 'todo', source: 'session-end' });
+  assert.strictEqual(res.ok, false);
+  assert.strictEqual(res.reason, 'done');
+  assert.strictEqual(store.getTicket(slug, a.ref).status, 'done', 'status stays done — not resurrected');
+});

--- a/plugins/sidequest/test/work.test.js
+++ b/plugins/sidequest/test/work.test.js
@@ -1,0 +1,107 @@
+'use strict';
+/**
+ * Tests for the headless drainer (SQ-154): lib/work.js planning + the
+ * `sidequest work --dry-run` CLI path.
+ *
+ * These NEVER spawn `claude` — they exercise planWork() (pure) and the --dry-run
+ * command, which compute exactly what WOULD be launched without launching it.
+ * The plan must have one entry per wave-1 ready ticket at its capped derived tier.
+ *
+ * Run: node --test plugins/sidequest/test/work.test.js
+ */
+const test = require('node:test');
+const assert = require('node:assert');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+
+const SIDEQUEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'sq-work-test-'));
+process.env.SIDEQUEST_HOME = SIDEQUEST_HOME;
+const PROJ = path.join(os.tmpdir(), 'sq-work-fixtures', 'board');
+process.env.CLAUDE_PROJECT_DIR = PROJ;
+
+const store = require('../lib/store.js');
+const work = require('../lib/work.js');
+const { slug } = store.ensureProject(PROJ);
+
+function add(title, complexity, files) {
+  return store.createTicket(slug, { title, complexity, complexityWhy: 'seed a ready ticket for the headless drain planning tests', files, source: 'cli' });
+}
+
+test('capTier keeps spawnable tiers and folds fable down to opus', () => {
+  assert.strictEqual(work.capTier('sonnet'), 'sonnet');
+  assert.strictEqual(work.capTier('opus'), 'opus');
+  assert.strictEqual(work.capTier('haiku'), 'haiku');
+  assert.strictEqual(work.capTier('fable'), 'opus');
+});
+
+test('planWork produces one spawn per wave-1 ready ticket, at its derived+capped tier, spawning nothing', () => {
+  store.setModelPrefs({ routing: true, opus: true, sonnet: true, haiku: true, fable: true });
+  // Two file-disjoint tickets -> same wave; one overlapping -> a later wave.
+  const a = add('a', 3, ['src/a.js']);
+  const b = add('b', 6, ['src/b.js']);
+  add('c', 4, ['src/a.js']); // overlaps a -> wave 2
+
+  const { plan, waveCount } = work.planWork(slug, { max: 5 });
+  assert.ok(waveCount >= 2, 'the overlapping ticket forces a second wave');
+  const refs = plan.map((p) => p.ref).sort();
+  assert.deepStrictEqual(refs, [a.ref, b.ref].sort(), 'wave 1 is the two disjoint tickets');
+
+  for (const p of plan) {
+    assert.ok(['opus', 'sonnet', 'haiku'].includes(p.tier), 'tier is a spawnable alias');
+    assert.match(p.by, /^headless-sq-\d+-[0-9a-f]{6}$/, 'each run gets a unique worker id');
+    // The argv is a real headless invocation carrying the model and JSON output;
+    // the (large, multi-line) prompt rides separately, over stdin.
+    assert.ok(p.argv.includes('-p'));
+    assert.strictEqual(p.argv[p.argv.indexOf('--model') + 1], p.tier);
+    assert.ok(p.argv.includes('--output-format') && p.argv.includes('json'));
+    assert.ok(!p.argv.some((a) => /ONE ticket/.test(a)), 'the prompt is NOT in argv (it goes over stdin)');
+    // The executor brief names the ticket and the claim-first protocol.
+    assert.match(p.prompt, new RegExp(`ONE ticket: ${p.ref}`));
+    assert.match(p.prompt, /CLAIM FIRST/);
+  }
+});
+
+test('--max caps the wave-1 batch and records how many were dropped', () => {
+  const res = work.planWork(slug, { max: 1 });
+  assert.strictEqual(res.plan.length, 1, 'only one run planned');
+  assert.ok(res.dropped >= 1, 'the rest of the wave is reported as dropped over --max');
+});
+
+test('a fable-derived ticket plans as opus (headless cap)', () => {
+  // Enable only fable so every derivation is fable, then confirm the plan caps it.
+  store.setModelPrefs({ routing: true, opus: false, sonnet: false, haiku: false, fable: true });
+  const t = store.createTicket(slug, { title: 'fable one', complexity: 9, complexityWhy: 'a high-complexity ticket that derives to the fable tier for the cap test', files: ['src/fable-only.js'], source: 'cli' });
+  const { plan } = work.planWork(slug, { max: 10 });
+  const entry = plan.find((p) => p.ref === t.ref);
+  assert.ok(entry, 'the fable ticket is in the plan');
+  assert.strictEqual(entry.tier, 'opus', 'fable caps to opus for a spawnable headless model');
+  store.setModelPrefs({ routing: true, opus: true, sonnet: true, haiku: true, fable: true });
+});
+
+test('permission posture: default acceptEdits, --yolo skips, explicit mode honored', () => {
+  const def = work.planWork(slug, { max: 1 }).plan[0];
+  assert.ok(def.argv.includes('--permission-mode') && def.argv.includes('acceptEdits'));
+  const yolo = work.planWork(slug, { max: 1, yolo: true }).plan[0];
+  assert.ok(yolo.argv.includes('--dangerously-skip-permissions'));
+  const plan = work.planWork(slug, { max: 1, permissionMode: 'plan' }).plan[0];
+  assert.strictEqual(plan.argv[plan.argv.indexOf('--permission-mode') + 1], 'plan');
+});
+
+test('the CLI `work --dry-run` prints a plan and spawns no process', () => {
+  const BIN = path.join(__dirname, '..', 'bin', 'sidequest.js');
+  const env = Object.assign({}, process.env, { SIDEQUEST_HOME, CLAUDE_PROJECT_DIR: PROJ });
+  const res = spawnSync(process.execPath, [BIN, 'work', '--dry-run', '--json'], { encoding: 'utf8', env });
+  assert.strictEqual(res.status, 0, res.stderr);
+  const out = JSON.parse(res.stdout);
+  assert.ok(Array.isArray(out.plan), 'dry-run emits a plan array');
+  assert.ok(out.plan.length >= 1, 'there is ready work to plan');
+  assert.ok(out.plan.every((p) => Array.isArray(p.argv)), 'each plan entry has an argv');
+});
+
+test('an empty board plans nothing', () => {
+  const empty = store.ensureProject(path.join(os.tmpdir(), 'sq-work-empty', 'board'));
+  const { plan } = work.planWork(empty.slug, {});
+  assert.deepStrictEqual(plan, []);
+});


### PR DESCRIPTION
Three Claude Code platform capabilities sidequest wasn't using yet, all aimed at cutting per-call cost and letting the board work more autonomously. Bumps the plugin to 1.32.0.

## What's in it

**1. MCP server** (`lib/mcp.js` + `bin/sidequest-mcp.js` + `.mcp.json`)
Agents work the board through typed `mcp__plugin_sidequest_board__*` tools instead of shelling out to `node bin/sidequest.js ...` on every action. One tool approval for the whole set instead of a Bash prompt per call, structured JSON in and out, and no heredoc/quoting trap on multi-line descriptions. It's a second entry point over the same `store.js` with the same guards (complexity+why on add, effort-drift on claim, atomic claim). Hand-rolled JSON-RPC 2.0 over stdio, no SDK, so the plugin stays dependency-free. The CLI stays as the human interface.

**2. Claims auto-release when a session ends** (`store.js` worker registry + `hooks/session-end.js` + `sidequest reconcile`)
A session's stale `doing` claims release back to `todo` the moment it ends, instead of waiting out the 60-minute TTL, so a dependent never sits blocked because someone closed a terminal mid-work. Session-scoped and safe (it only touches that session's own claims); the TTL stays the backstop. Registration is automatic via `CLAUDE_CODE_SESSION_ID`.

SubagentStop is deliberately **not** wired: there's no distinct per-subagent id in the payload, so reconciling there would risk releasing a whole wave's sibling claims. Within a live session the TTL still covers a dead subagent.

**3. Headless drainer** (`sidequest work`, `lib/work.js`)
Spawns one `claude -p` run per ready ticket at its derived tier, wave by wave, so the board drains without a live session. `--dry-run` prints the plan. Effort can't be set headless, so runs carry the model tier and run at its default effort (documented as the unattended-overflow path, not a replacement for interactive effort-pinned fan-out).

## Also

Fixes a TOCTOU in `releaseTicket`: it guarded only claim ownership, and `completeTicket` nulls the claim, so a reconcile racing behind a `done` could resurrect finished work back to `todo`. It now refuses a done ticket outright (mirrors `claimTicket`'s existing done-guard). Caught in review.

## Tests

23 new tests (`test/mcp.test.js`, `test/reconcile.test.js`, `test/work.test.js`), all green, including a real stdio round-trip against the MCP server and the reconcile race regression. The 4 failing tests in `test/hooks.test.js` are **pre-existing wording drift** (confirmed via `git stash` on clean `main`), not from this change — tracked separately.

## Notes for review / after merge

- The MCP server only **registers** after a `/reload-plugins` (or restart) picks up the new `.mcp.json`; the 1.32.0 version bump forces re-extraction.
- MCP config format cross-checked against the installed Playwright plugin's working `.mcp.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)