### PR TITLE
sidequest 1.33.1: lead with the MCP tools, demote the CLI to fallback

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,7 +34,7 @@
       "name": "sidequest",
       "source": "./plugins/sidequest",
       "description": "A Trello-light quest log for Claude Code. Side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
-      "version": "1.33.0",
+      "version": "1.33.1",
       "author": {
         "name": "Eigenwise"
       },

--- a/plugins/sidequest/.claude-plugin/plugin.json
+++ b/plugins/sidequest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sidequest",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "description": "A Trello-light quest log for Claude Code. The side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
   "author": {
     "name": "Eigenwise",

--- a/plugins/sidequest/agents/sidequest-exec-high.md
+++ b/plugins/sidequest/agents/sidequest-exec-high.md
@@ -24,6 +24,10 @@ can wander. A fast bounce-back is a success, not a failure.
 - Attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that root — get slug/id/
   filenames from `sidequest list --json`, then join the path.
 
+**Transport**: when `mcp__plugin_sidequest_board__*` tools are in your toolset, use them for every
+board action below (claim/comments/comment/done/release, same fields as the CLI flags); fall back to
+the `sidequest` CLI via Bash only when they aren't.
+
 Protocol, per ticket, in order:
 1. **Claim first**: `sidequest claim <ref> --by <worker-id> --effort high --project <project>`
    (add `--effort high` even if the command you were handed omits it — the board refuses the

--- a/plugins/sidequest/agents/sidequest-exec-low.md
+++ b/plugins/sidequest/agents/sidequest-exec-low.md
@@ -24,6 +24,10 @@ can wander. A fast bounce-back is a success, not a failure.
 - Attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that root — get slug/id/
   filenames from `sidequest list --json`, then join the path.
 
+**Transport**: when `mcp__plugin_sidequest_board__*` tools are in your toolset, use them for every
+board action below (claim/comments/comment/done/release, same fields as the CLI flags); fall back to
+the `sidequest` CLI via Bash only when they aren't.
+
 Protocol, per ticket, in order:
 1. **Claim first**: `sidequest claim <ref> --by <worker-id> --effort low --project <project>`
    (add `--effort low` even if the command you were handed omits it — the board refuses the

--- a/plugins/sidequest/agents/sidequest-exec-max.md
+++ b/plugins/sidequest/agents/sidequest-exec-max.md
@@ -24,6 +24,10 @@ can wander. A fast bounce-back is a success, not a failure.
 - Attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that root — get slug/id/
   filenames from `sidequest list --json`, then join the path.
 
+**Transport**: when `mcp__plugin_sidequest_board__*` tools are in your toolset, use them for every
+board action below (claim/comments/comment/done/release, same fields as the CLI flags); fall back to
+the `sidequest` CLI via Bash only when they aren't.
+
 Protocol, per ticket, in order:
 1. **Claim first**: `sidequest claim <ref> --by <worker-id> --effort max --project <project>`
    (add `--effort max` even if the command you were handed omits it — the board refuses the

--- a/plugins/sidequest/agents/sidequest-exec-medium.md
+++ b/plugins/sidequest/agents/sidequest-exec-medium.md
@@ -24,6 +24,10 @@ can wander. A fast bounce-back is a success, not a failure.
 - Attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that root — get slug/id/
   filenames from `sidequest list --json`, then join the path.
 
+**Transport**: when `mcp__plugin_sidequest_board__*` tools are in your toolset, use them for every
+board action below (claim/comments/comment/done/release, same fields as the CLI flags); fall back to
+the `sidequest` CLI via Bash only when they aren't.
+
 Protocol, per ticket, in order:
 1. **Claim first**: `sidequest claim <ref> --by <worker-id> --effort medium --project <project>`
    (add `--effort medium` even if the command you were handed omits it — the board refuses the

--- a/plugins/sidequest/agents/sidequest-exec-xhigh.md
+++ b/plugins/sidequest/agents/sidequest-exec-xhigh.md
@@ -24,6 +24,10 @@ can wander. A fast bounce-back is a success, not a failure.
 - Attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that root — get slug/id/
   filenames from `sidequest list --json`, then join the path.
 
+**Transport**: when `mcp__plugin_sidequest_board__*` tools are in your toolset, use them for every
+board action below (claim/comments/comment/done/release, same fields as the CLI flags); fall back to
+the `sidequest` CLI via Bash only when they aren't.
+
 Protocol, per ticket, in order:
 1. **Claim first**: `sidequest claim <ref> --by <worker-id> --effort xhigh --project <project>`
    (add `--effort xhigh` even if the command you were handed omits it — the board refuses the

--- a/plugins/sidequest/hooks/capture-nudge.js
+++ b/plugins/sidequest/hooks/capture-nudge.js
@@ -195,14 +195,16 @@ function main() {
   if (isMgmt && !strongCapture) {
     emit(
       '=== sidequest — board control ===\n' +
-        'Prefer the mcp__plugin_sidequest_board__* tools for board actions when available; otherwise the ' +
-        'CLI below (Bash tool, absolute path already resolved):\n' +
+        'Board actions go through the MCP tools when they are in your toolset: ' +
+        'mcp__plugin_sidequest_board__list / add / update / claim / next / done / release / comment / ' +
+        'ask / comments / link / models / projects (same fields as the CLI flags). Using Bash for a ' +
+        'board action when those tools are present is the wrong call — more prompts, shell-quoting ' +
+        'traps.\n' +
+        'The CLI (Bash, path already resolved) is the fallback, and the ONLY route to the dashboard:\n' +
         `  ${cli} dashboard    — open the live board; report the URL it prints\n` +
-        `  ${cli} list         — this project's tickets (--json to read; add --brief for a compact read)\n` +
-        `  ${cli} update SQ-3 --status done    — move/edit (also -p, -t, -d, -l) · rm SQ-3 — delete\n` +
-        'To WORK a ticket, claim it FIRST: `claim SQ-3 --by <you>` (or `next --by <you>`), then work, then ' +
-        '`done SQ-3 --by <you>` (`release` to drop it). Claiming is atomic — if it fails, do NOT work that ' +
-        'ticket; pick another.' +
+        `  ${cli} list --brief · update SQ-3 --status done · rm SQ-3\n` +
+        'To WORK a ticket, claim it FIRST (claim/next with a unique --by), then work, then done ' +
+        '(release to drop it). Claiming is atomic — if it fails, do NOT work that ticket; pick another.' +
         disciplineFooter()
     );
     process.exit(0);
@@ -227,7 +229,8 @@ function main() {
     'ticket right now, then carry on without derailing. (If it is only about the current task, ignore ' +
     'this.)\n' +
     'Preferred: spawn the `ticket-filer` subagent in the BACKGROUND (run_in_background: true) with a short ' +
-    'title, a one-line description, a priority, any labels, and any pasted image path. Or file directly:\n' +
+    'title, a one-line description, a priority, any labels, and any pasted image path. Or file directly: ' +
+    'mcp__plugin_sidequest_board__add when available, else\n' +
     `  ${cli} add -t "Short title" -d "What is wrong" -p high -l bug --complexity <1-10> --why "<motivation>"` +
     (images.length ? ` -i "${images[0]}"` : '') +
     '\n' +

--- a/plugins/sidequest/hooks/session-start.js
+++ b/plugins/sidequest/hooks/session-start.js
@@ -105,8 +105,10 @@ function main() {
       'ticket, one message).\n' +
       'Capture side issues the user mentions as tickets (background `ticket-filer`) without derailing ' +
       'the current task.\n' +
-      'Board: `' + cli + ' dashboard` — prefer the mcp__plugin_sidequest_board__* tools for board ' +
-      'actions when available.'
+      'Board actions (add/list/ready/claim/done/comment/...) go through the ' +
+      'mcp__plugin_sidequest_board__* MCP tools whenever they are in your toolset — reach for them ' +
+      'FIRST; Bash+CLI is the fallback and the only route to dashboard/serve/work. Open the board: `' +
+      cli + ' dashboard`.'
   );
   process.exit(0);
 }

--- a/plugins/sidequest/scripts/_exec-template.md
+++ b/plugins/sidequest/scripts/_exec-template.md
@@ -24,6 +24,10 @@ can wander. A fast bounce-back is a success, not a failure.
 - Attachment images: `projects/<slug>/assets/<ticket-id>/<filename>` under that root — get slug/id/
   filenames from `sidequest list --json`, then join the path.
 
+**Transport**: when `mcp__plugin_sidequest_board__*` tools are in your toolset, use them for every
+board action below (claim/comments/comment/done/release, same fields as the CLI flags); fall back to
+the `sidequest` CLI via Bash only when they aren't.
+
 Protocol, per ticket, in order:
 1. **Claim first**: `sidequest claim <ref> --by <worker-id> --effort {{EFFORT}} --project <project>`
    (add `--effort {{EFFORT}}` even if the command you were handed omits it — the board refuses the

--- a/plugins/sidequest/skills/sidequest/SKILL.md
+++ b/plugins/sidequest/skills/sidequest/SKILL.md
@@ -65,18 +65,23 @@ If the repo already uses Jira/Linear/GitHub Issues, that tracker owns the delive
 still your local execution ledger — see
 [references/external-trackers.md](references/external-trackers.md).
 
-## Finding the CLI, and preferring the MCP tools
+## The MCP tools ARE the board interface; the CLI is the fallback
 
-The SessionStart hook injects the **resolved absolute command** (`node "<path>/bin/sidequest.js"`)
-into your context — use exactly that with the Bash tool. In this file, `sidequest` is shorthand for
-that prefix. Commands default to the current project (`$CLAUDE_PROJECT_DIR`); add
-`--project "<path-or-slug>"` for another board.
-
-When tools named **`mcp__plugin_sidequest_board__*`** are in your toolset, **prefer them over the
-Bash CLI** for board actions — same store, same rules (complexity+why on `add`, effort guard on
+When tools named **`mcp__plugin_sidequest_board__*`** are in your toolset (`list`, `ready`, `add`,
+`update`, `claim`, `next`, `done`, `release`, `comment`, `ask`, `comments`, `link`, `assign`,
+`models`, `projects`), **every board action goes through them — reaching for Bash out of habit when
+they're present is the wrong call.** Same store, same rules (complexity+why on `add`, effort guard on
 `claim`, atomic claiming), but structured JSON in/out, one tool approval instead of a Bash prompt per
-call, and no shell-quoting trap (multi-line markdown bodies are plain strings). The CLI remains for
-humans, `dashboard`/`serve`, and the headless `work` drain.
+call, and no shell-quoting trap (multi-line markdown bodies are plain strings with real newlines).
+They take the same fields as the CLI flags shown below — the examples in this file use CLI form for
+compactness, not as a recommendation.
+
+The **CLI** is for when the MCP tools aren't loaded, for humans, and for the things only it does:
+`dashboard`/`serve` and the headless `work` drain. The SessionStart hook injects the **resolved
+absolute command** (`node "<path>/bin/sidequest.js"`) into your context — use exactly that with the
+Bash tool; `sidequest` in this file is shorthand for it. Commands default to the current project
+(`$CLAUDE_PROJECT_DIR`); add `--project "<path-or-slug>"` (MCP: the `project` field) for another
+board.
 
 **Where things live** (never scan the filesystem from root to find them): the CLI at
 `plugins/sidequest/bin/sidequest.js` under the installed plugin; ticket data under

--- a/plugins/sidequest/test/hooks.test.js
+++ b/plugins/sidequest/test/hooks.test.js
@@ -87,6 +87,10 @@ test('session-start: carries the route-down + tight-loop doctrine', () => {
   assert.ok(ctx.includes('bounce back'), 'must tell executors to bounce back, not wander');
   assert.ok(ctx.includes('ONE executor'), 'must carry the batch-small-tickets rule');
   assert.ok(ctx.includes('trivial one-step'), 'inline is only for trivial one-steps');
+  assert.ok(
+    ctx.includes('mcp__plugin_sidequest_board__') && ctx.includes('FIRST'),
+    'must push the MCP tools as the first-choice board interface (models default to the CLI out of habit)'
+  );
 });
 
 test('session-start: says sidequest coexists with an external tracker (Jira)', () => {
@@ -179,7 +183,10 @@ test('board-management block: fires on a dashboard prompt, carries claim discipl
   const ctx = capture('show me the dashboard');
   assert.ok(ctx.includes('board control'), 'a dashboard prompt should hit the mgmt block');
   assert.ok(ctx.includes('claim'), 'must carry the claim-first rule');
-  assert.ok(ctx.includes('mcp__plugin_sidequest_board__'), 'must point at the MCP tools first');
+  assert.ok(
+    ctx.indexOf('mcp__plugin_sidequest_board__') < ctx.indexOf('dashboard    —'),
+    'the MCP tools must LEAD the block, before any concrete CLI command (concrete beats abstract)'
+  );
   assert.ok(ctx.includes(FOOTER_MARK), 'must keep the one-line discipline footer');
   assert.ok(ctx.length <= BUDGET.mgmt, `mgmt block is ${ctx.length} chars — budget is ${BUDGET.mgmt}`);
   assertNoRetiredDoctrine(ctx, 'mgmt block');


### PR DESCRIPTION
Field test of 1.33.0 on a clean instance: the MCP server loads, but the model shells out to the CLI for every board action out of habit. The hooks hand it a concrete ready-to-paste CLI command while the MCP tools are just deferred names, and concrete beats abstract.

This hardens every prompt surface (SessionStart, board-control block, capture block, SKILL.md, exec agents) to lead with mcp__plugin_sidequest_board__* and demote the CLI to fallback plus the dashboard/serve/work paths only it covers. Tests now assert ordering (MCP tools before any concrete CLI command), not just presence. 108 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)