### PR TITLE
sidequest 1.37.1: sync and auto-update dashboard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,7 +57,7 @@
       "name": "sidequest",
       "source": "./plugins/sidequest",
       "description": "A Trello-light quest log for Claude Code. Side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
-      "version": "1.37.0",
+      "version": "1.37.1",
       "author": {
         "name": "Eigenwise"
       },

--- a/plugins/sidequest/.claude-plugin/plugin.json
+++ b/plugins/sidequest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sidequest",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "description": "A Trello-light quest log for Claude Code. The side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
   "author": {
     "name": "Eigenwise",

--- a/plugins/sidequest/bin/sidequest.js
+++ b/plugins/sidequest/bin/sidequest.js
@@ -1419,7 +1419,19 @@ async function cmdDashboard(opts) {
   if (opts.open === false) console.log('(browser auto-open skipped; open the URL above)');
 }
 
+async function waitForHandoff(pid, timeoutMs) {
+  if (!pid) return;
+  const deadline = Date.now() + (timeoutMs || 10 * 1000);
+  while (isPidAlive(pid)) {
+    if (Date.now() >= deadline) throw new Error(`handoff server pid ${pid} did not exit in time`);
+    await delay(100);
+  }
+}
+
 async function cmdServe(opts) {
+  // A successor spawned by server.js waits for the old listener to drain. This
+  // keeps active requests alive during the upgrade and then binds the same URL.
+  if (opts.handoffPid) await waitForHandoff(Number(opts.handoffPid));
   // Single-instance per home dir: a subagent smoke-testing "does serve start"
   // (or a human re-running it out of habit) used to spawn a second listener
   // on the next free port every time, leaving the old one running forever —

--- a/plugins/sidequest/dashboard/index.html
+++ b/plugins/sidequest/dashboard/index.html
@@ -1119,7 +1119,16 @@
   // case a future catalog carries colors.
   function adoptBackendColors() { CUSTOM_COLORS = {}; }
   function pushModelPrefs() {
-    return api("/api/model-prefs", { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(modelPrefs) }).catch(function () {});
+    return api("/api/model-prefs", { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(modelPrefs) })
+      .then(function (d) {
+        if (d && d.prefs) {
+          modelPrefs = d.prefs;
+          adoptBackendColors();
+          renderModelPrefSettings();
+        }
+        return d;
+      })
+      .catch(function () {});
   }
 
   // Routing-bias dial (-5 frugal .. 0 neutral .. +5 generous). Reflected from the

--- a/plugins/sidequest/lib/server.js
+++ b/plugins/sidequest/lib/server.js
@@ -16,7 +16,7 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const url = require('url');
-const { spawn } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
 const store = require('./store');
 const agentsync = require('./agentsync');
 
@@ -673,7 +673,7 @@ function startReminderScheduler() {
  *  SAME port deterministically (no surprise URL for an open browser tab).
  * ------------------------------------------------------------------ */
 
-const VERSION_WATCH_MS = 20 * 1000;
+const VERSION_WATCH_MS = Number(process.env.SIDEQUEST_VERSION_WATCH_MS) || 20 * 1000;
 const CLEAN_SEMVER_RE = /^\d+\.\d+\.\d+$/;
 
 // Runs the handoff at most once per process — a second tick firing mid-spawn
@@ -738,7 +738,30 @@ function findNewerInstall() {
   }
 }
 
+// Confirm that the successor's entrypoint can at least load before we stop
+// serving. A half-written or corrupt cached install is the common failed-upgrade
+// case; leave the current dashboard alone and retry after the next watch tick.
+function canRunInstall(targetBin) {
+  try {
+    const targetRoot = path.resolve(targetBin, '..', '..');
+    for (const file of [targetBin, path.join(targetRoot, 'lib', 'server.js')]) {
+      const result = spawnSync(process.execPath, ['--check', file], {
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+      if (result.error || result.status !== 0) return false;
+    }
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
 // Poll for a newer sibling install and hand the port off exactly once.
+// The successor waits for this process rather than reaping it: server.close()
+// stops new connections but lets active API requests complete before the old
+// process exits. A bad cached install fails the preflight above, so the current
+// dashboard keeps serving instead of disappearing mid-upgrade.
 // Returns the interval handle so start() can fold it into its cleanup
 // alongside the reminder timer.
 function startVersionWatch(server, ownPort, reminderTimer) {
@@ -747,6 +770,14 @@ function startVersionWatch(server, ownPort, reminderTimer) {
       if (recycling) return;
       const targetBin = findNewerInstall();
       if (!targetBin) return;
+      if (!canRunInstall(targetBin)) {
+        try {
+          process.stderr.write(`sidequest: newer install failed preflight (${targetBin}) — keeping the current dashboard\n`);
+        } catch (_) {
+          /* best effort */
+        }
+        return;
+      }
       recycling = true;
       try {
         process.stderr.write(`sidequest: newer install found (${targetBin}) — handing off port ${ownPort}\n`);
@@ -755,10 +786,15 @@ function startVersionWatch(server, ownPort, reminderTimer) {
       }
       let child;
       try {
-        child = spawn(process.execPath, [targetBin, 'serve', '--port', String(ownPort)], {
+        child = spawn(process.execPath, [targetBin, 'serve', '--port', String(ownPort), '--handoff-pid', String(process.pid)], {
           detached: true,
           stdio: 'ignore',
           windowsHide: true,
+        });
+        child.once('error', () => {
+          // Before close() begins, an OS-level spawn failure leaves this server
+          // healthy and lets a later watch tick retry the install.
+          recycling = false;
         });
         child.unref();
       } catch (_) {
@@ -766,22 +802,17 @@ function startVersionWatch(server, ownPort, reminderTimer) {
         recycling = false;
         return;
       }
-      // Only after a successful spawn do we free the port for the successor:
-      // stop our own timers and listener, then drop the lockfile if it's ours.
       clearInterval(reminderTimer);
       clearInterval(watchTimer);
-      try {
-        server.close();
-      } catch (_) {
-        /* best effort */
-      }
-      try {
-        const cur = store.readServerInfo();
-        if (cur && cur.pid === process.pid) store.clearServerInfo();
-      } catch (_) {
-        /* best effort */
-      }
-      process.exit(0);
+      server.close(() => {
+        try {
+          const cur = store.readServerInfo();
+          if (cur && cur.pid === process.pid) store.clearServerInfo();
+        } catch (_) {
+          /* best effort */
+        }
+        process.exit(0);
+      });
     } catch (_) {
       /* fail-soft: a watch hiccup must never take the server down */
     }

--- a/plugins/sidequest/test/server.test.js
+++ b/plugins/sidequest/test/server.test.js
@@ -8,6 +8,8 @@ const assert = require('node:assert');
 const os = require('os');
 const path = require('path');
 const fs = require('fs');
+const http = require('http');
+const { spawn } = require('child_process');
 
 // Point the store at a throwaway home so any incidental store reads/writes
 // (findNewerInstall never touches it, but requiring server.js pulls in
@@ -123,4 +125,118 @@ test('dashboard presents execution profiles before advanced ladder controls', ()
 
 test('findNewerInstall: never throws even with guards disabled', () => {
   assert.doesNotThrow(() => findNewerInstall());
+});
+
+function copyPlugin(from, to, version) {
+  fs.cpSync(from, to, { recursive: true });
+  const manifest = path.join(to, '.claude-plugin', 'plugin.json');
+  const plugin = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+  plugin.version = version;
+  fs.writeFileSync(manifest, `${JSON.stringify(plugin, null, 2)}\n`);
+}
+
+function waitFor(check, timeoutMs, label) {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const tick = async () => {
+      try {
+        if (await check()) {
+          resolve();
+          return;
+        }
+        if (Date.now() >= deadline) {
+          reject(new Error(`timed out waiting for ${label}`));
+          return;
+        }
+        setTimeout(tick, 50);
+      } catch (_) {
+        if (Date.now() >= deadline) {
+          reject(new Error(`timed out waiting for ${label}`));
+          return;
+        }
+        setTimeout(tick, 50);
+      }
+    };
+    tick();
+  });
+}
+
+function fetchJson(port, endpoint) {
+  return new Promise((resolve, reject) => {
+    http.get({ host: '127.0.0.1', port, path: endpoint, timeout: 1000 }, (res) => {
+      let body = '';
+      res.on('data', (chunk) => (body += chunk));
+      res.on('end', () => {
+        try {
+          resolve(JSON.parse(body));
+        } catch (err) {
+          reject(err);
+        }
+      });
+    }).on('error', reject);
+  });
+}
+
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+test('dashboard self-updates to a newer cached install at the same URL', { timeout: 20000 }, async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sq-dashboard-upgrade-'));
+  const oldRoot = path.join(root, '1.37.0');
+  const newRoot = path.join(root, '1.37.1');
+  const source = path.join(__dirname, '..');
+  const home = path.join(root, 'home');
+  copyPlugin(source, oldRoot, '1.37.0');
+
+  const port = 43000 + Math.floor(Math.random() * 1000);
+  const env = Object.assign({}, process.env, {
+    SIDEQUEST_HOME: home,
+    SIDEQUEST_VERSION_WATCH_MS: '100',
+  });
+  delete env.SIDEQUEST_NO_HOT_RECYCLE;
+  const old = spawn(process.execPath, [path.join(oldRoot, 'bin', 'sidequest.js'), 'serve', '--port', String(port)], {
+    env,
+    stdio: 'ignore',
+    windowsHide: true,
+  });
+  t.after(() => {
+    for (const child of [old]) {
+      if (child.pid && isAlive(child.pid)) {
+        try { process.kill(child.pid); } catch (_) {}
+      }
+    }
+    try { fs.rmSync(root, { recursive: true, force: true }); } catch (_) {}
+  });
+
+  await waitFor(async () => {
+    try {
+      const health = await fetchJson(port, '/api/health');
+      return health.version === '1.37.0';
+    } catch (_) {
+      return false;
+    }
+  }, 5000, 'the old dashboard');
+
+  const oldHealth = await fetchJson(port, '/api/health');
+  copyPlugin(source, newRoot, '1.37.1');
+
+  await waitFor(async () => {
+    try {
+      const health = await fetchJson(port, '/api/health');
+      return health.version === '1.37.1';
+    } catch (_) {
+      return false;
+    }
+  }, 10000, 'the upgraded dashboard');
+
+  const newHealth = await fetchJson(port, '/api/health');
+  assert.strictEqual(newHealth.version, '1.37.1');
+  assert.notStrictEqual(newHealth.pid, oldHealth.pid);
+  assert.strictEqual(isAlive(old.pid), false);
 });


### PR DESCRIPTION
Fixes the execution-plan cards staying stale after backend dropdown changes. The live dashboard now watches for newer cached Sidequest installs and hands the same port to the newer server automatically, so users no longer need to ask for a manual dashboard restart after releases.\n\nVerification: 172 Sidequest tests pass, including an end-to-end same-port 1.37.0 → 1.37.1 server handoff.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)