### PR TITLE
sidequest 1.38.0: grade-based routing and native temp executors

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,7 +57,7 @@
       "name": "sidequest",
       "source": "./plugins/sidequest",
       "description": "A Trello-light quest log for Claude Code. Side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
-      "version": "1.37.1",
+      "version": "1.38.0",
       "author": {
         "name": "Eigenwise"
       },

--- a/plugins/sidequest/.claude-plugin/plugin.json
+++ b/plugins/sidequest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sidequest",
-  "version": "1.37.1",
+  "version": "1.38.0",
   "description": "A Trello-light quest log for Claude Code. The side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
   "author": {
     "name": "Eigenwise",

--- a/plugins/sidequest/README.md
+++ b/plugins/sidequest/README.md
@@ -1,5 +1,9 @@
 # sidequest
 
+# ⚠️ UNDER HEAVY CONSTRUCTION
+
+**Sidequest is changing quickly and may break, reroute work unexpectedly, or require migration between releases. Don't rely on it for critical unattended work yet.**
+
 [![Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FEigenwise%2Feigenwise-toolshed%2Fmain%2Fplugins%2Fsidequest%2F.claude-plugin%2Fplugin.json&query=%24.version&label=version&color=blue)](.claude-plugin/plugin.json)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-D97757?logo=claude&logoColor=white)](https://claude.com/claude-code)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](../../LICENSE)

--- a/plugins/sidequest/bin/sidequest.js
+++ b/plugins/sidequest/bin/sidequest.js
@@ -370,7 +370,7 @@ function effortDriftReason(slug, idOrRef, claimedEffort) {
   if (prefs.routing === false) return null;
   const t = store.getTicket(slug, idOrRef); // carries derived model/effort at read time
   if (!t || !t.complexity) return null;
-  if (t.model === 'haiku' || !t.effort) return null;
+  if (t.model === 'grade-1' || !t.effort) return null;
   const claimed = String(claimedEffort).toLowerCase();
   if (claimed === t.effort) return null;
   // The read already resolved which agent to spawn (t.exec.agent): a Claude tier
@@ -936,6 +936,34 @@ function cmdUnarchive(opts, positional) {
     process.exitCode = 1;
     console.log(`✗ unarchive: no ticket "${idOrRef}" in ${meta.name}`);
   }
+}
+
+function cmdNativeAgent(opts, positional) {
+  const action = String(positional[0] || '').toLowerCase();
+  if (action === 'cleanup') {
+    const sessionId = opts.session || process.env.CLAUDE_CODE_SESSION_ID || process.env.CLAUDE_SESSION_ID;
+    if (!opts.name && !sessionId) fail('native-agent cleanup: pass --name or run inside a Claude Code session.');
+    const res = agentsync.cleanupNativeAgents({ name: opts.name, sessionId });
+    process.stdout.write(JSON.stringify(res, null, 2) + '\n');
+    return;
+  }
+
+  const idOrRef = positional[0];
+  if (!idOrRef) fail('native-agent: pass a ticket ref, e.g. sidequest native-agent SQ-12 --json.');
+  const { slug } = resolveProject(opts);
+  const ticket = store.getTicket(slug, idOrRef);
+  if (!ticket) fail(`native-agent: no ticket "${idOrRef}".`);
+  if (!ticket.model || !ticket.effort) fail(`native-agent: ${ticket.ref} has no routable model and effort.`);
+  const resolved = store.resolveExec(ticket.model, ticket.effort, store.getModelPrefs());
+  const sessionId = opts.session || process.env.CLAUDE_CODE_SESSION_ID || process.env.CLAUDE_SESSION_ID || null;
+  const created = agentsync.createNativeAgent({
+    ref: ticket.ref,
+    modelId: resolved.spawnId,
+    effort: ticket.effort,
+    grade: ticket.model,
+    sessionId,
+  });
+  process.stdout.write(JSON.stringify(Object.assign({ project: slug, ref: ticket.ref }, created), null, 2) + '\n');
 }
 
 // `sidequest models sync-agents` — regenerate the runtime
@@ -1525,6 +1553,10 @@ Headless / autonomous draining (work the board without an interactive session):
     session. Effort isn't
     settable headless, so a run carries the ticket's MODEL and runs at that model's default effort. Safe
     beside an interactive session — claiming stays atomic. Needs the \`claude\` CLI on PATH.
+  sidequest native-agent <SQ-n> [--json]             write a temporary native Agent definition and return its spawn spec
+  sidequest native-agent cleanup --name <name>        remove one temporary native Agent definition
+    Native Agent definitions pin the resolved backend model, effort, bypass permission mode, and neutral
+    grade identity. They hot-reload for the current session; remove them after the Agent finishes.
   sidequest reconcile [--session <id>] [--reason "..."]   release a session's stale claims back to todo now
     (the SessionEnd hook calls this automatically on the session id it's given, so a crashed/ended worker's
     tickets recover immediately instead of waiting out the claim TTL; safe — it only touches that session's
@@ -1692,6 +1724,10 @@ async function main() {
     case 'unarchive':
     case 'restore':
       cmdUnarchive(opts, positional);
+      break;
+    case 'native-agent':
+    case 'native_agent':
+      cmdNativeAgent(opts, positional);
       break;
     case 'models':
       cmdModels(opts, positional);

--- a/plugins/sidequest/dashboard/index.html
+++ b/plugins/sidequest/dashboard/index.html
@@ -216,12 +216,12 @@
   .profile-band { display: block; margin-top: 3px; font-family: var(--mono); font-size: 10.5px; color: var(--text-faint); }
   .profile-runtime { text-align: right; font-size: 11.5px; color: var(--text-dim); }
   .profile-runtime b { display: block; color: var(--text); font-weight: 600; }
-  .edit-plan { margin-top: 10px; display: flex; justify-content: flex-end; }
-  .edit-plan button, .advanced-routing summary { border: 1px solid var(--line); background: var(--card); color: var(--text-dim); border-radius: var(--radius-sm); font: 600 11.5px var(--sans); cursor: pointer; }
-  .edit-plan button { padding: 6px 10px; }
+  .routing-direct-controls { margin-top: 14px; border-top: 1px solid var(--line-soft); padding-top: 8px; }
+  .routing-direct-controls .pop-head { padding-left: 0; }
+  .routing-direct-controls .model-pref-list { margin-bottom: 10px; }
+  .advanced-routing summary { border: 1px solid var(--line); background: var(--card); color: var(--text-dim); border-radius: var(--radius-sm); font: 600 11.5px var(--sans); cursor: pointer; }
   .advanced-routing { grid-column: 1 / -1; border-top: 1px solid var(--line-soft); }
   .advanced-routing summary { list-style: none; margin: 10px 18px; padding: 7px 10px; width: fit-content; }
-  .advanced-routing summary::-webkit-details-marker { display: none; }
   .advanced-routing summary::before { content: "+"; margin-right: 7px; color: var(--gold); }
   .advanced-routing[open] summary::before { content: "−"; }
   .advanced-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); border-top: 1px solid var(--line-soft); }
@@ -748,7 +748,7 @@
                 <label class="pop-row routing-toggle"><input type="checkbox" id="routingEnabled" /><span>Automatic</span></label>
               </div>
               <div class="routing-profiles" id="routingProfiles"></div>
-              <div class="edit-plan"><button type="button" id="editPlanBtn">Edit plan</button></div>
+              <div class="routing-direct-controls"><div class="pop-head">Effort controls</div><div class="model-pref-list" id="modelPrefList"></div><div class="pop-head">Band preference</div><div class="bias-view" id="biasView"></div><div class="backend-warn" id="tierBackendWarn"></div></div>
             </section>
             <div class="sp-col">
               <div class="pop-head">Desktop notifications</div>
@@ -769,15 +769,6 @@
             <details class="advanced-routing" id="advancedRouting">
               <summary>Advanced routing</summary>
               <div class="advanced-grid">
-                <div class="sp-col">
-                  <div class="pop-head">Runtimes &amp; effort</div>
-                  <div class="model-pref-list" id="modelPrefList"></div>
-                  <div class="backend-warn" id="tierBackendWarn"></div>
-                </div>
-                <div class="sp-col">
-                  <div class="pop-head">Band preference</div>
-                  <div class="bias-view" id="biasView"></div>
-                </div>
                 <div class="sp-col">
                   <div class="pop-head">Exact C1–C10 ladder</div>
                   <div class="ladder-view" id="ladderView"></div>
@@ -969,10 +960,12 @@
   // — the filer must pick one; there is no default. Each tier gets a distinct
   // on-brand accent so the card chip is glanceable.
   var MODELS = [
-    { k: "opus", label: "Opus" }, { k: "sonnet", label: "Sonnet" },
-    { k: "haiku", label: "Haiku" }, { k: "fable", label: "Fable" }
+    { k: "grade-1", label: "Grade 1", hint: "small, tightly-scoped work" },
+    { k: "grade-2", label: "Grade 2", hint: "everyday coding work" },
+    { k: "grade-3", label: "Grade 3", hint: "hard multi-file work" },
+    { k: "grade-4", label: "Grade 4", hint: "the hardest work" }
   ];
-  var MODEL_COLORS = { opus: "#404683", sonnet: "#3f8f8a", haiku: "#a8672e", fable: "#7a5ba8" };
+  var MODEL_COLORS = { "grade-1": "#a8672e", "grade-2": "#3f8f8a", "grade-3": "#404683", "grade-4": "#7a5ba8" };
   // A detected (codex-gateway) model can carry its own color; otherwise give it
   // a stable on-brand hue derived from the slug so its ladder rung and card chip
   // read the same every time. modelColor() is the single lookup everything uses.
@@ -1096,14 +1089,14 @@
   function defaultEffortsMatrix() {
     var out = {};
     MODELS.forEach(function (m) {
-      if (m.k === "haiku") return;
+      if (m.k === "grade-1") return;
       var row = {};
       EFFORTS.forEach(function (ef) { row[ef.k] = true; });
       out[m.k] = row;
     });
     return out;
   }
-  var modelPrefs = { opus: true, sonnet: true, haiku: true, fable: true, routing: true, efforts: defaultEffortsMatrix() };
+  var modelPrefs = { "grade-1": true, "grade-2": true, "grade-3": true, "grade-4": true, routing: true, efforts: defaultEffortsMatrix() };
   function modelEnabled(k) { return modelPrefs[k] !== false; }
   function effortEnabled(model, k) {
     var row = modelPrefs.efforts && modelPrefs.efforts[model];
@@ -1719,7 +1712,7 @@
       headRow.appendChild(h);
     });
     grid.appendChild(headRow);
-    MODELS.filter(function (m) { return m.k !== "haiku"; }).forEach(function (m) {
+    MODELS.filter(function (m) { return m.k !== "grade-1"; }).forEach(function (m) {
       var tierOn = modelEnabled(m.k);
       var row = el("div", "eg-row" + (tierOn ? "" : " dim"));
       var label = el("span", "eg-label");
@@ -1767,20 +1760,20 @@
       toggle.checked = modelPrefs.routing !== false;
       toggle.onchange = function () { modelPrefs.routing = toggle.checked; pushModelPrefs(); };
     }
-    var profilesView = modelPrefs.profiles || {};
-    var profiles = Array.isArray(profilesView) ? profilesView : ["routine", "everyday", "complex", "frontier"].map(function (k) { return profilesView[k]; }).filter(Boolean);
+    var gradesView = modelPrefs.profiles || {};
+    var grades = MODELS.map(function (m) { return gradesView[m.k]; }).filter(Boolean);
     box.innerHTML = "";
-    profiles.forEach(function (p) {
+    grades.forEach(function (p) {
       var row = el("div", "profile-row" + (p.enabled === false ? " muted" : ""));
       var cs = (p.complexities || []).map(function (n) { return "C" + n; }).join(", ") || "No active scores";
-      row.innerHTML = '<span class="profile-dot" style="background:' + modelColor(p.tier) + '"></span>' +
-        '<span><span class="profile-name">' + esc(p.profile[0].toUpperCase() + p.profile.slice(1)) + '</span><span class="profile-band">' + esc(cs) + '</span></span>' +
-        '<span class="profile-runtime"><b>' + esc(p.runsLabel || p.runsModel || p.tier) + '</b>' + esc(p.backend === "codex" ? "Codex runtime" : "Claude runtime") + '</span>';
+      row.innerHTML = '<span class="profile-dot" style="background:' + modelColor(p.grade) + '"></span>' +
+        '<span><span class="profile-name">' + esc(p.label || p.grade) + '</span><span class="profile-band">' + esc(cs) + '</span></span>' +
+        '<span class="profile-runtime"><b>' + esc(p.runsLabel || p.runsModel) + '</b>' + esc(p.backend === "codex" ? "Codex runtime" : "Claude runtime") + '</span>';
+      var det = modelPrefs.discovered || [];
+      if (det.length) row.appendChild(backendSelect(p.grade, det));
       box.appendChild(row);
     });
-    if (!profiles.length) box.innerHTML = '<div class="ladder-empty">Loading execution plan…</div>';
-    var edit = $("editPlanBtn");
-    if (edit) edit.onclick = function () { var a = $("advancedRouting"); if (a) { a.open = true; a.scrollIntoView({ block: "nearest" }); } };
+    if (!grades.length) box.innerHTML = '<div class="ladder-empty">Loading grades…</div>';
   }
 
   // Per-tier backend (1.36.0): each tier runs on its Claude model by default, or
@@ -1799,7 +1792,10 @@
     var sel = document.createElement("select");
     sel.setAttribute("aria-label", tier + " backend model");
     var cur = currentBackend(tier);
-    var opts = ['<option value="claude"' + (cur === "claude" ? " selected" : "") + ">Claude " + esc(tier[0].toUpperCase() + tier.slice(1)) + "</option>"];
+    // The "claude" option names the actual Claude runtime backing this grade —
+    // never the grade itself (grades are neutral IDs, runtimes are models).
+    var claudeRuntime = { "grade-1": "Claude Haiku", "grade-2": "Claude Sonnet", "grade-3": "Claude Opus", "grade-4": "Claude Fable" }[tier] || "Claude";
+    var opts = ['<option value="claude"' + (cur === "claude" ? " selected" : "") + ">" + esc(claudeRuntime) + "</option>"];
     det.forEach(function (dm) {
       var suggested = dm.suggestedTier === tier ? " (suggested)" : "";
       opts.push('<option value="' + esc(dm.slug) + '"' + (cur === dm.slug ? " selected" : "") + ">" + esc(dm.label) + suggested + "</option>");
@@ -1813,9 +1809,10 @@
       renderModelPrefSettings();
       pushModelPrefs().then(function () { refreshLadder(); });
       var dm = det.filter(function (x) { return x.slug === sel.value; })[0];
+      var gradeLabel = { "grade-1": "Grade 1", "grade-2": "Grade 2", "grade-3": "Grade 3", "grade-4": "Grade 4" }[tier] || tier;
       toast(sel.value === "claude"
-        ? tier + " tier runs on Claude"
-        : tier + " tier now runs on " + (dm ? dm.label : sel.value) + " — regenerating its executor agents");
+        ? gradeLabel + " runs on " + claudeRuntime
+        : gradeLabel + " now runs on " + (dm ? dm.label : sel.value) + " — regenerating its executor agents");
     });
     wrap.appendChild(sel);
     return wrap;

--- a/plugins/sidequest/hooks/session-end.js
+++ b/plugins/sidequest/hooks/session-end.js
@@ -53,6 +53,7 @@ function main() {
   }
   try {
     store.reconcileSession(String(sessionId), { reason, source: 'session-end' });
+    require(path.join(pluginRoot(), 'lib', 'agentsync.js')).cleanupNativeAgents({ sessionId: String(sessionId) });
   } catch (_) {
     /* best effort */
   }

--- a/plugins/sidequest/hooks/session-start.js
+++ b/plugins/sidequest/hooks/session-start.js
@@ -58,7 +58,9 @@ function pluginRoot() {
 // a sync problem can NEVER break session start. Empty catalog -> no-op.
 function provisionExecAgents() {
   try {
-    require(path.join(pluginRoot(), 'lib', 'agentsync.js')).syncExecAgents();
+    const sync = require(path.join(pluginRoot(), 'lib', 'agentsync.js'));
+    sync.cleanupNativeAgents({ staleBefore: Date.now() - 6 * 60 * 60 * 1000 });
+    sync.syncExecAgents();
   } catch (_) {
     /* best effort — never break the session over agent provisioning */
   }

--- a/plugins/sidequest/lib/agentsync.js
+++ b/plugins/sidequest/lib/agentsync.js
@@ -35,6 +35,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const crypto = require('crypto');
 const discovery = require('./discovery.js');
 
 const TEMPLATE_PATH = path.join(__dirname, '..', 'scripts', '_exec-template.md');
@@ -42,6 +43,8 @@ const TEMPLATE_PATH = path.join(__dirname, '..', 'scripts', '_exec-template.md')
 // Marks a file as ours. Must stay unique enough that no human-authored agent
 // file would plausibly contain it verbatim.
 const MARKER = '<!-- generated-by: sidequest-agentsync -->';
+const TEMP_MARKER = '<!-- generated-by: sidequest-native-agent -->';
+const TEMP_PREFIX = 'sidequest-native-';
 
 // The effort axis a generated agent's frontmatter can pin — `max` is the
 // sparing top rung (see store.js's routingLadder) and, like the five shipped
@@ -97,6 +100,99 @@ function renderBackendAgent(slug, id, effort) {
     marker: MARKER,
     extraNote: backendNote(slug, id),
   });
+}
+
+function nativeAgentName(ref, nonce) {
+  const ticket = String(ref || 'ticket').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'ticket';
+  const suffix = String(nonce || crypto.randomBytes(4).toString('hex')).toLowerCase();
+  if (!/^[a-z0-9]{6,32}$/.test(suffix)) throw new Error('native agent nonce must be 6-32 lowercase alphanumeric characters.');
+  return `${TEMP_PREFIX}${ticket}-${suffix}`;
+}
+
+function nativeAgentFile(name, dir) {
+  if (!String(name || '').startsWith(TEMP_PREFIX)) throw new Error('native agent name must use the Sidequest temporary prefix.');
+  return path.join(dir || defaultAgentsDir(), `${name}.md`);
+}
+
+function nativeAgentSource(spec) {
+  const tools = Array.isArray(spec.tools) && spec.tools.length ? spec.tools : ['Read', 'Glob', 'Grep', 'Edit', 'Write', 'Bash', 'SendMessage'];
+  if (!tools.every((tool) => /^[A-Za-z][A-Za-z0-9:_-]*$/.test(String(tool)))) throw new Error('native agent tools must be valid tool names.');
+  const model = String(spec.modelId || '').trim();
+  const effort = String(spec.effort || '').trim();
+  const grade = String(spec.grade || '').trim();
+  if (!model || /[\r\n]/.test(model)) throw new Error('native agent model id is required and must be one line.');
+  if (!NON_MAX_EFFORTS.includes(effort)) throw new Error(`native agent effort must be one of: ${NON_MAX_EFFORTS.join(', ')}.`);
+  if (!/^grade-[1-4]$/.test(grade)) throw new Error('native agent grade must be a neutral grade-1 through grade-4 identifier.');
+  const session = String(spec.sessionId || '').replace(/[\r\n]/g, '');
+  return [
+    '---',
+    `name: ${spec.name}`,
+    'description: Temporary Sidequest native executor. Removed after this run.',
+    `model: ${model}`,
+    `effort: ${effort}`,
+    `tools: ${tools.join(', ')}`,
+    'permissionMode: bypassPermissions',
+    '---',
+    TEMP_MARKER,
+    `<!-- sidequest-native-session: ${session} -->`,
+    `<!-- sidequest-native-grade: ${grade} -->`,
+    'You are a temporary Sidequest executor. Follow the exact task prompt from your parent. Stay within its ticket scope, verify the requested behavior, and report concise evidence. The parent owns orchestration. Before ending after success or failure, run the cleanup command supplied in your task prompt.',
+    '',
+  ].join('\n');
+}
+
+// Claude Code sees user-scoped agent definitions without a plugin rebuild. The
+// short synchronous debounce lets its watcher register the new definition before
+// the caller invokes Agent; tests pass waitMs: 0.
+function waitForNativeAgentReload(waitMs) {
+  const ms = Number.isFinite(Number(waitMs)) ? Math.max(0, Number(waitMs)) : 175;
+  if (ms > 0) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function createNativeAgent(spec, opts) {
+  opts = opts || {};
+  const dir = opts.dir || defaultAgentsDir();
+  const name = nativeAgentName(spec && spec.ref, spec && spec.nonce);
+  const source = nativeAgentSource(Object.assign({}, spec, { name }));
+  fs.mkdirSync(dir, { recursive: true });
+  const file = nativeAgentFile(name, dir);
+  fs.writeFileSync(file, source, { flag: 'wx' });
+  waitForNativeAgentReload(opts.waitMs);
+  return {
+    name,
+    file,
+    spawn: {
+      subagent_type: name,
+      name,
+      mode: 'bypassPermissions',
+    },
+    cleanup: { name, sessionId: spec.sessionId || null },
+  };
+}
+
+function cleanupNativeAgents(opts) {
+  opts = opts || {};
+  const dir = opts.dir || defaultAgentsDir();
+  const name = opts.name ? String(opts.name) : null;
+  const sessionId = opts.sessionId == null ? null : String(opts.sessionId);
+  let removed = 0;
+  let files = [];
+  try { files = fs.readdirSync(dir).filter((f) => f.startsWith(TEMP_PREFIX) && f.endsWith('.md')); } catch (_) { return { removed }; }
+  for (const fileName of files) {
+    if (name && fileName !== `${name}.md`) continue;
+    const file = path.join(dir, fileName);
+    let source = '';
+    try { source = fs.readFileSync(file, 'utf8'); } catch (_) { continue; }
+    if (!source.includes(TEMP_MARKER)) continue;
+    if (sessionId && !source.includes(`<!-- sidequest-native-session: ${sessionId} -->`)) continue;
+    if (opts.staleBefore != null) {
+      let stat;
+      try { stat = fs.statSync(file); } catch (_) { continue; }
+      if (stat.mtimeMs >= Number(opts.staleBefore)) continue;
+    }
+    try { fs.unlinkSync(file); removed++; } catch (_) { /* best effort */ }
+  }
+  return { removed };
 }
 
 // Regenerate the runtime Codex exec agents. The wanted set is a pure function of
@@ -192,9 +288,15 @@ function syncExecAgents(prefs, opts) {
 
 module.exports = {
   MARKER,
+  TEMP_MARKER,
+  TEMP_PREFIX,
   NON_MAX_EFFORTS,
   agentFileName,
   renderExecAgent,
+  createNativeAgent,
+  cleanupNativeAgents,
+  nativeAgentName,
+  nativeAgentSource,
   syncExecAgents,
   defaultAgentsDir,
 };

--- a/plugins/sidequest/lib/discovery.js
+++ b/plugins/sidequest/lib/discovery.js
@@ -36,7 +36,10 @@ const SLUG_RE = /^[a-z0-9][a-z0-9-]{1,31}$/;
 
 // Mirrors store.js's VALID_MODELS. Duplicated rather than imported so
 // discovery.js stays a leaf module with zero sidequest dependencies.
-const VALID_TIERS = ['haiku', 'sonnet', 'opus', 'fable'];
+const VALID_TIERS = ['grade-1', 'grade-2', 'grade-3', 'grade-4'];
+// Catalog files (codex-gateway schema-2, and the older schema-1 `anchor`) still
+// carry provider-family hints; normalize those to grade IDs at this boundary.
+const LEGACY_TIER_HINTS = { haiku: 'grade-1', sonnet: 'grade-2', opus: 'grade-3', fable: 'grade-4' };
 
 // Catalogs this version of sidequest knows how to read, each resolved as
 // <discovery root>/<relPath>. Add an entry here for the next sibling plugin.
@@ -82,7 +85,8 @@ function validateEntry(raw, source) {
   const id = typeof raw.id === 'string' ? raw.id.trim() : '';
   if (!id) return null;
   const hintRaw = raw.suggestedTier != null ? raw.suggestedTier : raw.anchor;
-  const hint = typeof hintRaw === 'string' ? hintRaw.trim().toLowerCase() : '';
+  const hintNorm = typeof hintRaw === 'string' ? hintRaw.trim().toLowerCase() : '';
+  const hint = LEGACY_TIER_HINTS[hintNorm] || hintNorm;
   const suggestedTier = VALID_TIERS.indexOf(hint) !== -1 ? hint : null;
   const label = typeof raw.label === 'string' && raw.label.trim() ? raw.label.trim() : slug;
   return { slug, id, label, suggestedTier, source };

--- a/plugins/sidequest/lib/mcp.js
+++ b/plugins/sidequest/lib/mcp.js
@@ -26,6 +26,7 @@ const path = require('path');
 const fs = require('fs');
 const store = require('./store');
 const work = require('./work');
+const agentsync = require('./agentsync');
 
 const SERVER_NAME = 'sidequest';
 // The latest MCP protocol revision we implement. In `initialize` we echo the
@@ -96,7 +97,7 @@ function effortDrift(slug, idOrRef, claimedEffort) {
   if (prefs.routing === false) return null;
   const t = store.getTicket(slug, idOrRef);
   if (!t || !t.complexity) return null;
-  if (t.model === 'haiku' || !t.effort) return null;
+  if (t.model === 'grade-1' || !t.effort) return null;
   const claimed = String(claimedEffort).toLowerCase();
   if (claimed === t.effort) return null;
   // The ticket read already resolved which agent to spawn (t.exec.agent): a
@@ -154,11 +155,11 @@ function requireKnownModelFilter(action, value, prefs) {
 function requireKnownModel(action, value, prefs) {
   if (value == null || !String(value).trim()) return;
   const s = String(value).trim().toLowerCase();
-  const known = store.VALID_MODELS.indexOf(s) !== -1
-    || (prefs.discovered || []).some((d) => d.slug === s);
+  const known = store.coerceModel(s) || (prefs.discovered || []).some((d) => d.slug === s);
   if (!known) {
     const slugs = (prefs.discovered || []).map((d) => d.slug);
-    throw new Error(`${action}: unknown model "${value}" — known: ${store.VALID_MODELS.concat(slugs).join(', ')}`);
+    const aliases = ['haiku', 'sonnet', 'opus', 'fable'];
+    throw new Error(`${action}: unknown model "${value}" — known: ${store.VALID_MODELS.concat(aliases, slugs).join(', ')}`);
   }
 }
 
@@ -198,7 +199,7 @@ const TOOLS = [
       type: 'object',
       properties: {
         project: PROJECT_PROP,
-        model: { type: 'string', description: 'Filter to one derived tier — a built-in (opus/sonnet/haiku/fable) or any slug listed by the models tool. Omit for no filter; an unrecognized value errors.' },
+        model: { type: 'string', description: 'Filter to a derived grade (grade-1 through grade-4). Deprecated aliases are accepted as input.' },
         brief: { type: 'boolean', description: 'Compact tickets: ref/title/status/priority/complexity/model/effort/files/claim/blockedBy, plus a comments count and awaitingReply. No bodies.' },
       },
     },
@@ -321,7 +322,7 @@ const TOOLS = [
       properties: {
         project: PROJECT_PROP,
         by: { type: 'string' },
-        model: { type: 'string', description: 'Filter to one derived tier — a built-in (opus/sonnet/haiku/fable) or any slug listed by the models tool. Omit for no filter; an unrecognized value errors.' },
+        model: { type: 'string', description: 'Filter to a derived grade (grade-1 through grade-4). Deprecated aliases are accepted as input.' },
         priority: { type: 'string', enum: store.VALID_PRIORITY },
         session: { type: 'string' },
       },
@@ -345,7 +346,7 @@ const TOOLS = [
         ref: { type: 'string' },
         project: PROJECT_PROP,
         by: { type: 'string' },
-        model: { type: 'string', description: 'The model tier that actually worked this ticket (provenance) — a built-in (opus/sonnet/haiku/fable) or any slug listed by the models tool.' },
+        model: { type: 'string', description: 'The grade or runtime model that actually worked this ticket (provenance).' },
         effort: { type: 'string', enum: store.VALID_EFFORTS },
         session: { type: 'string' },
       },
@@ -473,6 +474,49 @@ const TOOLS = [
       const res = store.assignTicket(slug, args.ref, who, { source: 'mcp' });
       if (!res.ok) throw new Error(`assign: no ticket "${args.ref}".`);
       return Object.assign({ project: slug }, res);
+    },
+  },
+  {
+    name: 'native_agent',
+    description: 'Create one temporary, backend-pinned native Agent definition for a ticket in this Claude Code session. Call it immediately before Agent, pass the returned spawn object unchanged plus your task prompt, then call native_agent_cleanup after the Agent finishes. The returned grade is neutral; model names stay out of routing identifiers.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string' },
+        project: PROJECT_PROP,
+        prompt: { type: 'string', description: 'The bounded ticket-execution prompt passed unchanged to the native Agent.' },
+        tools: { type: 'array', items: { type: 'string' }, description: 'Optional native Agent tool allowlist.' },
+        session: { type: 'string' },
+      },
+      required: ['ref', 'prompt'],
+    },
+    handler(args) {
+      const { slug } = resolveProject(args.project);
+      const ticket = store.getTicket(slug, args.ref);
+      if (!ticket) throw new Error(`native_agent: no ticket "${args.ref}".`);
+      if (!ticket.model || !ticket.effort) throw new Error(`native_agent: ${ticket.ref} has no routable model and effort.`);
+      const resolved = store.resolveExec(ticket.model, ticket.effort, store.getModelPrefs());
+      const created = agentsync.createNativeAgent({
+        ref: ticket.ref,
+        modelId: resolved.spawnId,
+        effort: ticket.effort,
+        grade: ticket.model,
+        tools: args.tools,
+        sessionId: sessionOf(args),
+      });
+      return Object.assign({ project: slug, ref: ticket.ref, prompt: args.prompt }, created);
+    },
+  },
+  {
+    name: 'native_agent_cleanup',
+    description: 'Remove a temporary Sidequest native Agent definition after its Agent run ends or the session is cleaning up. Pass the name returned by native_agent, or session to remove that session\'s stale files.',
+    inputSchema: {
+      type: 'object',
+      properties: { name: { type: 'string' }, session: { type: 'string' } },
+    },
+    handler(args) {
+      if (!args.name && !sessionOf(args)) throw new Error('native_agent_cleanup: pass name or session.');
+      return agentsync.cleanupNativeAgents({ name: args.name, sessionId: sessionOf(args) });
     },
   },
   {

--- a/plugins/sidequest/lib/store.js
+++ b/plugins/sidequest/lib/store.js
@@ -155,72 +155,45 @@ function newTicketId() {
 const VALID_STATUS = ['todo', 'doing', 'done'];
 const VALID_PRIORITY = ['low', 'normal', 'high', 'urgent'];
 
-// The agent tier a ticket wants working it — the same aliases Claude Code's Task
-// tool accepts, so the orchestrator can pass a ticket's tag straight through as a
-// subagent's model (plan with the top tier, execute a tier down). Required on
-// every ticket at the entry points; the filing agent chooses by complexity.
-// sidequest can't *force* a model (only the orchestrator picks one at spawn
-// time); this tag drives that routing and the `next`/`ready` --model filter.
-const VALID_MODELS = ['opus', 'sonnet', 'haiku', 'fable'];
+// Routing identity is intentionally provider-neutral. A grade owns the capability
+// slot; its runtime assignment says what actually executes work in that slot.
+const VALID_MODELS = ['grade-1', 'grade-2', 'grade-3', 'grade-4'];
+const LEGACY_TIER_GRADE = { haiku: 'grade-1', sonnet: 'grade-2', opus: 'grade-3', fable: 'grade-4' };
+const GRADE_TIER = { 'grade-1': 'haiku', 'grade-2': 'sonnet', 'grade-3': 'opus', 'grade-4': 'fable' };
+const GRADE_LABELS = { 'grade-1': 'Grade 1', 'grade-2': 'Grade 2', 'grade-3': 'Grade 3', 'grade-4': 'Grade 4' };
 
 /* ------------------------------------------------------------------ *
- *  Execution profiles (SQ-188)
- *
- *  The provider-neutral, user-facing names of the routing plan. Each profile is
- *  a stable alias for exactly one internal capability tier — the ladder, the
- *  scoring, the persisted prefs file, and every tested routing invariant still
- *  run on the four tiers; a profile just lets the user (and the dashboard's
- *  execution-plan UI) reason about "what kind of work" without caring which
- *  vendor model currently backs it (that's the tier's backend, see tierBackend).
- *
- *    routine  → haiku    small chores
- *    everyday → sonnet   bread-and-butter work
- *    complex  → opus     hard, multi-file work
- *    frontier → fable    the genuinely hardest work
+ *  Grades and deprecated input aliases
  * ------------------------------------------------------------------ */
-const EXECUTION_PROFILES = ['routine', 'everyday', 'complex', 'frontier'];
-const PROFILE_TIER = { routine: 'haiku', everyday: 'sonnet', complex: 'opus', frontier: 'fable' };
-const TIER_PROFILE = { haiku: 'routine', sonnet: 'everyday', opus: 'complex', fable: 'frontier' };
-// Human display names for a Claude-backed tier in the derived profiles view.
-// resolveExec's runsLabel keeps its raw tier value (a tested shape); this is
-// purely the friendlier string the plan UI shows for "what runs this profile".
-const CLAUDE_TIER_LABELS = { haiku: 'Claude Haiku', sonnet: 'Claude Sonnet', opus: 'Claude Opus', fable: 'Claude Fable' };
 
-// A profile OR tier name → the internal tier, else null.
+// The old provider-family names and short-lived task-shape names remain accepted
+// at input boundaries only. They never appear in canonical reads or prefs files.
+const EXECUTION_PROFILES = VALID_MODELS.slice();
+const PROFILE_TIER = {
+  routine: 'grade-1', everyday: 'grade-2', complex: 'grade-3', frontier: 'grade-4',
+  haiku: 'grade-1', sonnet: 'grade-2', opus: 'grade-3', fable: 'grade-4',
+};
+const TIER_PROFILE = Object.assign({}, GRADE_TIER);
+const CLAUDE_TIER_LABELS = {
+  'grade-1': 'Claude Haiku', 'grade-2': 'Claude Sonnet',
+  'grade-3': 'Claude Opus', 'grade-4': 'Claude Fable',
+};
+
 function tierForProfile(v) {
   if (v == null) return null;
   const s = String(v).trim().toLowerCase();
-  if (PROFILE_TIER[s]) return PROFILE_TIER[s];
-  return VALID_MODELS.indexOf(s) !== -1 ? s : null;
+  return VALID_MODELS.includes(s) ? s : (PROFILE_TIER[s] || null);
 }
 
-// A tier OR profile name → the neutral profile, else null.
 function profileForTier(v) {
-  if (v == null) return null;
-  const s = String(v).trim().toLowerCase();
-  if (TIER_PROFILE[s]) return TIER_PROFILE[s];
-  return PROFILE_TIER[s] ? s : null;
+  return tierForProfile(v);
 }
 
-// Normalize a requested model tier to one of VALID_MODELS, or null. Blank /
-// "any" / "none" / an unknown alias all coerce to null — which is exactly what
-// the entry points (CLI add, dashboard POST) reject: every ticket must be filed
-// with a real tier, and sidequest never picks one for you. The data layer itself
-// stays permissive/fail-soft (the capture hook must never crash).
-//
-// Tiers are ALWAYS the four built-ins — a Codex model is a per-tier BACKEND
-// (which real model actually runs an opus-tier ticket), not a ladder tier of its
-// own, so it never appears here. `prefs` is accepted for signature stability but
-// no longer widens the vocabulary. The old tier aliases (haiku/sonnet/opus/
-// fable) stay first-class for compatibility; a neutral profile name (routine/
-// everyday/complex/frontier) resolves to its tier, so both vocabularies work at
-// every entry point that takes a model.
 function coerceModel(v, _prefs) {
   if (v == null) return null;
   const s = String(v).trim().toLowerCase();
   if (!s || s === 'any' || s === 'none' || s === 'null') return null;
-  if (VALID_MODELS.indexOf(s) !== -1) return s;
-  return PROFILE_TIER[s] || null;
+  return VALID_MODELS.includes(s) ? s : (PROFILE_TIER[s] || null);
 }
 
 // How hard the executor should think — the reasoning-effort levels Claude Code
@@ -235,7 +208,7 @@ const VALID_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'];
 // The tiers that carry an effort axis — every model except haiku (which has no
 // reasoning-effort support). model-prefs stores one effort row per tier here, so
 // a single (model, effort) combo like opus·medium can be excluded on its own.
-const EFFORT_MODELS = VALID_MODELS.filter((m) => m !== 'haiku');
+const EFFORT_MODELS = VALID_MODELS.filter((m) => m !== 'grade-1');
 
 function coerceEffort(v) {
   if (v == null) return null;
@@ -283,15 +256,16 @@ function discoveredBySlug() {
 function normalizeTierBackend(raw) {
   const out = {};
   const src = raw && typeof raw === 'object' ? raw : {};
-  for (const tier of VALID_MODELS) {
-    const v = src[tier];
+  for (const grade of VALID_MODELS) {
+    const legacy = GRADE_TIER[grade];
+    const v = src[grade] !== undefined ? src[grade] : src[legacy];
     if (typeof v === 'string') {
       const s = v.trim().toLowerCase();
-      if (s === 'claude' || s === '' || s === tier) out[tier] = 'claude';
-      else if (BACKEND_SLUG_RE.test(s)) out[tier] = s;
-      else out[tier] = 'claude';
+      if (s === 'claude' || s === '' || s === legacy) out[grade] = 'claude';
+      else if (BACKEND_SLUG_RE.test(s)) out[grade] = s;
+      else out[grade] = 'claude';
     } else {
-      out[tier] = 'claude';
+      out[grade] = 'claude';
     }
   }
   return out;
@@ -307,16 +281,17 @@ function resolveTierBackends(tierBackend) {
   const catalog = discoveredBySlug();
   const byTier = {};
   const warnings = [];
-  for (const tier of VALID_MODELS) {
-    const v = map[tier];
+  for (const grade of VALID_MODELS) {
+    const v = map[grade];
+    const legacy = GRADE_TIER[grade];
     if (v !== 'claude' && catalog[v]) {
       const d = catalog[v];
-      byTier[tier] = { backend: 'codex', slug: d.slug, id: d.id, label: d.label };
+      byTier[grade] = { backend: 'codex', slug: d.slug, id: d.id, label: d.label };
     } else {
       if (v !== 'claude' && !catalog[v]) {
-        warnings.push(`${tier} tier is mapped to "${v}", which isn't currently available — falling back to Claude ${tier}`);
+        warnings.push(`${GRADE_LABELS[grade]} is mapped to "${v}", which isn't currently available — falling back to Claude ${legacy}`);
       }
-      byTier[tier] = { backend: 'claude', slug: null, id: null, label: null };
+      byTier[grade] = { backend: 'claude', slug: null, id: null, label: null };
     }
   }
   return { byTier, warnings };
@@ -332,31 +307,28 @@ function resolveTierBackends(tierBackend) {
 // frontmatter); spawnId is the raw model string for the headless `claude -p`
 // path. effort is the ticket's stamped effort (null only for a Claude haiku tier;
 // a Codex-backed haiku uses HAIKU_BACKEND_EFFORT for its agent).
-function resolveExec(tier, effort, prefs) {
+function resolveExec(grade, effort, prefs) {
+  grade = coerceModel(grade);
   prefs = prefs || getModelPrefs();
   const { byTier } = resolveTierBackends(prefs.tierBackend);
-  const b = byTier[tier] || { backend: 'claude', slug: null, id: null };
+  const legacy = GRADE_TIER[grade];
+  const b = byTier[grade] || { backend: 'claude', slug: null, id: null };
   if (b.backend === 'codex') {
     const eff = effort || HAIKU_BACKEND_EFFORT;
-    // runsLabel is the human name of what actually runs, for a visible spawn
-    // announcement (e.g. "GPT-5.6 Terra"); runsModel is its slug.
     return { agent: `sidequest-exec-${b.slug}-${eff}`, model: null, spawnId: b.id, backend: 'codex', slug: b.slug, runsModel: b.slug, runsLabel: b.label || b.slug };
   }
-  // Claude-backed. haiku has no effort agent (plain agent, model: haiku).
-  if (tier === 'haiku' || !effort) {
-    return { agent: null, model: tier, spawnId: tier, backend: 'claude', slug: null, runsModel: tier, runsLabel: tier };
+  if (grade === 'grade-1' || !effort) {
+    return { agent: null, model: legacy, spawnId: legacy, backend: 'claude', slug: null, runsModel: legacy, runsLabel: legacy };
   }
-  return { agent: `sidequest-exec-${effort}`, model: tier, spawnId: tier, backend: 'claude', slug: null, runsModel: tier, runsLabel: tier };
+  return { agent: `sidequest-exec-${effort}`, model: legacy, spawnId: legacy, backend: 'claude', slug: null, runsModel: legacy, runsLabel: legacy };
 }
 
 // Resolve a stamped model name to the real string handed to Claude Code at spawn
 // time. A ticket stamps a TIER; if that tier is Codex-backed, the real model is
 // the mapped id, else the tier maps to itself. Unknown names → null.
-function resolveModelId(tierName, prefs) {
-  if (tierName == null) return null;
-  const s = String(tierName).trim().toLowerCase();
-  if (VALID_MODELS.indexOf(s) === -1) return null;
-  return resolveExec(s, null, prefs).spawnId;
+function resolveModelId(gradeName, prefs) {
+  const grade = coerceModel(gradeName);
+  return grade ? resolveExec(grade, null, prefs).spawnId : null;
 }
 
 // The routing vocabulary: tickets/filters/provenance name one of the four TIERS.
@@ -393,7 +365,7 @@ function classifyModelFilter(v, _prefs) {
 
 // Capability order, weakest first — the axis the ladder scales along.
 // (VALID_MODELS is unordered vocabulary; this is the ranking.)
-const MODEL_CAPABILITY_ORDER = ['haiku', 'sonnet', 'opus', 'fable'];
+const MODEL_CAPABILITY_ORDER = VALID_MODELS.slice();
 
 // An integer score 1..10, or null when absent/garbage.
 function coerceComplexity(v) {
@@ -444,7 +416,7 @@ function coerceRoutingBias(v) {
 //     ceiling) as the rung directly below it instead of being skipped.
 // Bump a tier's offset further above its neighbor's to weaken/eliminate overlap
 // there (more tier-major); pull it closer to widen the crossover band.
-const LADDER_TIER_BASE = { haiku: 0, sonnet: 2, opus: 4, fable: 8 };
+const LADDER_TIER_BASE = { 'grade-1': 0, 'grade-2': 2, 'grade-3': 4, 'grade-4': 8 };
 // The effort axis the score indexes along (max held out — it's the sparing top
 // rung, ranked separately). Position in this list == a rung's effortIndex.
 const LADDER_EFFORT_ORDER = ['low', 'medium', 'high', 'xhigh'];
@@ -492,15 +464,13 @@ function routingLadder(prefs) {
       model: m,
       base: LADDER_TIER_BASE[m],
       tierRank: MODEL_CAPABILITY_ORDER.indexOf(m),
-      row: m === 'haiku' ? null : builtinRow(m),
-      haiku: m === 'haiku',
+      row: m === 'grade-1' ? null : builtinRow(m),
+      haiku: m === 'grade-1',
     });
   }
-  // Never return an empty ladder: fall back to a single sonnet tier, seeded from
-  // its own row so an all-false efforts object still yields the medium fallback
-  // below. Unreachable via setModelPrefs (the tier guard keeps a built-in on).
+  // Never return an empty ladder: fall back to Grade 2.
   if (!tiers.length) {
-    tiers.push({ model: 'sonnet', base: LADDER_TIER_BASE.sonnet, tierRank: MODEL_CAPABILITY_ORDER.indexOf('sonnet'), row: builtinRow('sonnet'), haiku: false });
+    tiers.push({ model: 'grade-2', base: LADDER_TIER_BASE['grade-2'], tierRank: MODEL_CAPABILITY_ORDER.indexOf('grade-2'), row: builtinRow('grade-2'), haiku: false });
   }
 
   // ENUMERATE every enabled combo programmatically and score it by capability.
@@ -511,7 +481,7 @@ function routingLadder(prefs) {
   const seq = [];
   for (const tier of tiers) {
     if (tier.haiku) {
-      seq.push({ model: 'haiku', effort: null, tierRank: tier.tierRank, score: tier.base });
+      seq.push({ model: 'grade-1', effort: null, tierRank: tier.tierRank, score: tier.base });
       continue;
     }
     let tierEfforts = seqEffortsOf(tier.row);
@@ -619,18 +589,14 @@ function applyDerivedRouting(t, prefs) {
       // tells the orchestrator to announce which model actually runs (runsLabel).
       t.exec = { agent: ex.agent, model: ex.model, backend: ex.backend, runsModel: ex.runsModel, runsLabel: ex.runsLabel };
     }
-  } else if (VALID_MODELS.indexOf(t.model) !== -1) {
-    // Legacy no-complexity ticket with a stored tier tag: the tag is honored
-    // (nothing re-derives it), but the READ still resolves what would actually
-    // run it, so a Codex-backed tier can't silently fall back to the generic
-    // Claude executor path just because the ticket predates complexity scoring.
+  } else if (coerceModel(t.model)) {
+    // Legacy no-complexity ticket: normalize deprecated tier aliases on read.
+    t.model = coerceModel(t.model);
     prefs = prefs || getModelPrefs();
     const ex = resolveExec(t.model, t.effort || null, prefs);
     t.exec = { agent: ex.agent, model: ex.model, backend: ex.backend, runsModel: ex.runsModel, runsLabel: ex.runsLabel };
   }
-  // Every read carries the neutral profile of whatever tier the ticket routed
-  // (or was tagged) to — the user-facing name for "SQ-n · Cn Profile · …" lines.
-  t.profile = TIER_PROFILE[t.model] || null;
+  t.profile = t.model || null;
   return t;
 }
 
@@ -1534,8 +1500,8 @@ function makeWorkedBy(input, _prefs) {
   if (!input) return null;
   const rawModel = input.model;
   if (rawModel == null || String(rawModel).trim() === '') return null; // no stamp when not provided
-  const model = String(rawModel).trim().toLowerCase();
-  const known = VALID_MODELS.indexOf(model) !== -1 || !!discoveredBySlug()[model];
+  const model = coerceModel(rawModel) || String(rawModel).trim().toLowerCase();
+  const known = VALID_MODELS.indexOf(model) !== -1 || !!PROFILE_TIER[model] || !!discoveredBySlug()[model];
   if (!known) {
     throw new Error(`invalid model "${rawModel}" — expected one of: ${VALID_MODELS.join(', ')} (or a discovered Codex model)`);
   }
@@ -2190,19 +2156,17 @@ function deriveProfilesView(prefs) {
   const byTier = prefs.tierBackendResolved || resolveTierBackends(prefs.tierBackend).byTier;
   const ladder = routingLadder(prefs);
   const out = {};
-  for (const profile of EXECUTION_PROFILES) {
-    const tier = PROFILE_TIER[profile];
-    const b = byTier[tier] || { backend: 'claude', slug: null, id: null, label: null };
-    const complexities = [];
-    for (const r of ladder) if (r.model === tier) complexities.push(r.complexity);
-    out[profile] = {
-      profile,
-      tier,
-      enabled: prefs[tier] !== false,
+  for (const grade of VALID_MODELS) {
+    const b = byTier[grade] || { backend: 'claude', slug: null, id: null, label: null };
+    const complexities = ladder.filter((r) => r.model === grade).map((r) => r.complexity);
+    out[grade] = {
+      grade,
+      label: GRADE_LABELS[grade],
+      enabled: prefs[grade] !== false,
       backend: b.backend,
-      runsModel: b.backend === 'codex' ? b.slug : tier,
-      runsLabel: b.backend === 'codex' ? (b.label || b.slug) : CLAUDE_TIER_LABELS[tier],
-      efforts: tier === 'haiku' ? null : Object.assign({}, (prefs.efforts && prefs.efforts[tier]) || {}),
+      runsModel: b.backend === 'codex' ? b.slug : GRADE_TIER[grade],
+      runsLabel: b.backend === 'codex' ? (b.label || b.slug) : CLAUDE_TIER_LABELS[grade],
+      efforts: grade === 'grade-1' ? null : Object.assign({}, (prefs.efforts && prefs.efforts[grade]) || {}),
       complexities,
       range: complexities.length ? [complexities[0], complexities[complexities.length - 1]] : null,
     };
@@ -2230,46 +2194,37 @@ function translateProfilePatch(patch) {
   if (!patch || typeof patch !== 'object') return {};
   const out = Object.assign({}, patch);
   const src = patch.profiles && typeof patch.profiles === 'object' ? patch.profiles : null;
-  if ('profiles' in out) delete out.profiles;
-  const explicitTierBackend = patch.tierBackend && typeof patch.tierBackend === 'object' ? patch.tierBackend : {};
+  delete out.profiles;
+  const explicitBackend = patch.tierBackend && typeof patch.tierBackend === 'object' ? patch.tierBackend : {};
   const explicitEfforts = patch.efforts && typeof patch.efforts === 'object' ? patch.efforts : {};
   if (src) {
-    for (const profile of EXECUTION_PROFILES) {
-      if (!(profile in src)) continue;
-      const tier = PROFILE_TIER[profile];
-      const v = src[profile];
+    for (const alias of Object.keys(src)) {
+      const grade = coerceModel(alias);
+      if (!grade) continue;
+      const v = src[alias];
       if (v && typeof v === 'object') {
-        if ('enabled' in v && !(tier in patch)) out[tier] = v.enabled !== false;
-        if ('backend' in v && !(tier in explicitTierBackend)) {
-          out.tierBackend = Object.assign({}, out.tierBackend, { [tier]: v.backend });
+        if ('enabled' in v && !(grade in patch)) out[grade] = v.enabled !== false;
+        if ('backend' in v && !(grade in explicitBackend)) out.tierBackend = Object.assign({}, out.tierBackend, { [grade]: v.backend });
+        if (grade !== 'grade-1' && v.efforts && typeof v.efforts === 'object') {
+          out.efforts = Object.assign({}, out.efforts, { [grade]: Object.assign({}, v.efforts, explicitEfforts[grade]) });
         }
-        if (tier !== 'haiku' && v.efforts && typeof v.efforts === 'object') {
-          // Profile efforts sit UNDER any explicit row for the same tier.
-          out.efforts = Object.assign({}, out.efforts);
-          out.efforts[tier] = Object.assign({}, v.efforts, explicitEfforts[tier]);
-        }
-      } else if (!(tier in patch)) {
-        out[tier] = v !== false;
-      }
+      } else if (!(grade in patch)) out[grade] = v !== false;
     }
   }
-  // Bare profile names as top-level tier-boolean aliases: { frontier: false }.
-  for (const profile of EXECUTION_PROFILES) {
-    if (profile in out) {
-      const tier = PROFILE_TIER[profile];
-      const v = out[profile];
-      delete out[profile];
-      if (typeof v !== 'object' && !(tier in patch)) out[tier] = v !== false;
-    }
+  for (const alias of Object.keys(PROFILE_TIER)) {
+    if (!(alias in out)) continue;
+    const grade = PROFILE_TIER[alias];
+    const v = out[alias];
+    delete out[alias];
+    if (typeof v !== 'object' && !(grade in patch)) out[grade] = v !== false;
   }
-  // Profile names as tierBackend keys: { tierBackend: { complex: <slug> } }.
   if (out.tierBackend && typeof out.tierBackend === 'object') {
     const tb = Object.assign({}, out.tierBackend);
-    for (const profile of EXECUTION_PROFILES) {
-      if (profile in tb) {
-        const tier = PROFILE_TIER[profile];
-        if (!(tier in explicitTierBackend)) tb[tier] = tb[profile];
-        delete tb[profile];
+    for (const alias of Object.keys(PROFILE_TIER)) {
+      if (alias in tb) {
+        const grade = PROFILE_TIER[alias];
+        if (!(grade in explicitBackend)) tb[grade] = tb[alias];
+        delete tb[alias];
       }
     }
     out.tierBackend = tb;
@@ -2297,14 +2252,19 @@ function getModelPrefs() {
   const saved = readJson(modelPrefsFile(), null);
   const merged = saved && typeof saved === 'object' ? saved : {};
   const out = {};
-  for (const m of VALID_MODELS) out[m] = merged[m] !== false;
+  for (const grade of VALID_MODELS) {
+    const legacy = GRADE_TIER[grade];
+    out[grade] = merged[grade] !== false && merged[legacy] !== false;
+  }
 
   const savedEfforts = merged.efforts && typeof merged.efforts === 'object' ? merged.efforts : null;
   // Only fall back to legacy flat keys when there's no matrix at all.
   const hasLegacyFlat = !savedEfforts && VALID_EFFORTS.some((e) => e in merged);
   out.efforts = {};
   for (const m of EFFORT_MODELS) {
-    const savedRow = savedEfforts && merged.efforts[m] && typeof merged.efforts[m] === 'object' ? merged.efforts[m] : null;
+    const legacy = GRADE_TIER[m];
+    const savedRow = savedEfforts && (merged.efforts[m] || merged.efforts[legacy]) && typeof (merged.efforts[m] || merged.efforts[legacy]) === 'object'
+      ? (merged.efforts[m] || merged.efforts[legacy]) : null;
     const row = {};
     for (const e of VALID_EFFORTS) {
       if (savedRow) row[e] = savedRow[e] !== false;
@@ -2330,17 +2290,8 @@ function getModelPrefs() {
   out.tierBackendWarnings = resolvedBackends.warnings;
   out.discovered = discoverExternalModels();
 
-  if (merged.customOverrides !== undefined || merged.custom !== undefined) {
-    const persisted = Object.assign({}, merged);
-    delete persisted.customOverrides;
-    delete persisted.custom;
-    persisted.tierBackend = out.tierBackend;
-    writeJson(modelPrefsFile(), persisted);
-  }
-
-  // The neutral execution-plan view (SQ-188): derived fresh from the tier
-  // prefs above on every read, alongside (never instead of) the tier keys.
   out.profiles = deriveProfilesView(out);
+  if (JSON.stringify(merged) !== JSON.stringify(persistedPrefs(out))) writeJson(modelPrefsFile(), persistedPrefs(out));
   return out;
 }
 
@@ -2355,6 +2306,16 @@ function getModelPrefs() {
 // is written to disk. Per-row guard mirrors the tier guard: each model row keeps
 // at least one effort enabled (fallback medium). The `routing` switch and
 // `routingBias` dial carry through independently; routingBias clamps on write.
+function persistedPrefs(prefs) {
+  const out = {};
+  for (const grade of VALID_MODELS) out[grade] = prefs[grade] !== false;
+  out.efforts = prefs.efforts;
+  out.routing = prefs.routing !== false;
+  out.routingBias = coerceRoutingBias(prefs.routingBias);
+  out.tierBackend = normalizeTierBackend(prefs.tierBackend);
+  return out;
+}
+
 function setModelPrefs(patch) {
   const cur = getModelPrefs();
   // Profile-keyed patches (the neutral execution-plan vocabulary, SQ-188) are
@@ -2365,7 +2326,7 @@ function setModelPrefs(patch) {
 
   // Tiers: carried from the current set unless the patch names them.
   for (const m of VALID_MODELS) out[m] = (m in patch) ? patch[m] !== false : cur[m];
-  if (!VALID_MODELS.some((m) => out[m])) out[VALID_MODELS.indexOf('sonnet') !== -1 ? 'sonnet' : VALID_MODELS[0]] = true;
+  if (!VALID_MODELS.some((m) => out[m])) out['grade-2'] = true;
 
   // Efforts: start from the current matrix, layer any legacy flat keys over every
   // row, then layer a nested patch row per-key on top (nested wins over flat).
@@ -2375,7 +2336,9 @@ function setModelPrefs(patch) {
   for (const m of EFFORT_MODELS) {
     const row = Object.assign({}, cur.efforts[m]);
     for (const e of flatKeys) row[e] = patch[e] !== false;
-    const pr = patchEfforts && patchEfforts[m] && typeof patchEfforts[m] === 'object' ? patchEfforts[m] : null;
+    const legacy = GRADE_TIER[m];
+    const pr = patchEfforts && (patchEfforts[m] || patchEfforts[legacy]) && typeof (patchEfforts[m] || patchEfforts[legacy]) === 'object'
+      ? (patchEfforts[m] || patchEfforts[legacy]) : null;
     if (pr) for (const e of VALID_EFFORTS) { if (e in pr) row[e] = pr[e] !== false; }
     if (!VALID_EFFORTS.some((e) => row[e])) row.medium = true; // per-row guard: never leave a tier effortless
     out.efforts[m] = row;
@@ -2392,13 +2355,15 @@ function setModelPrefs(patch) {
   // and the resolved backends are re-derived on read, never persisted.
   const mergedBackend = Object.assign({}, cur.tierBackend);
   if (patch.tierBackend && typeof patch.tierBackend === 'object') {
-    for (const tier of VALID_MODELS) {
-      if (tier in patch.tierBackend) mergedBackend[tier] = patch.tierBackend[tier];
+    for (const grade of VALID_MODELS) {
+      const legacy = GRADE_TIER[grade];
+      if (grade in patch.tierBackend) mergedBackend[grade] = patch.tierBackend[grade];
+      else if (legacy in patch.tierBackend) mergedBackend[grade] = patch.tierBackend[legacy];
     }
   }
   out.tierBackend = normalizeTierBackend(mergedBackend);
 
-  writeJson(modelPrefsFile(), out);
+  writeJson(modelPrefsFile(), persistedPrefs(out));
 
   // Resolve after the write so the persisted file carries only tierBackend, while
   // the returned object also has the derived catalog + resolution for callers.

--- a/plugins/sidequest/lib/work.js
+++ b/plugins/sidequest/lib/work.js
@@ -36,11 +36,19 @@ const DEFAULT_MAX_WAVES = 5; // safety cap on how many waves one drain will chew
 // alias, so a fable-derived ticket runs headless as opus; the other three tiers
 // pass through. This only applies to CLAUDE-backed tiers — a tier pointed at a
 // Codex model resolves to that model's id instead (see resolveSpawnModel).
-const SPAWNABLE = new Set(['opus', 'sonnet', 'haiku']);
+// Grades are the routing identifiers everywhere in the plan; only the final
+// `claude -p --model` argv needs a real Claude alias. capTier stays in grade
+// space: grade-4's runtime (Fable) has no headless alias, so it caps to grade-3.
+const SPAWNABLE_GRADES = new Set(['grade-1', 'grade-2', 'grade-3']);
+const GRADE_SPAWN_ALIAS = { 'grade-1': 'haiku', 'grade-2': 'sonnet', 'grade-3': 'opus' };
 function capTier(model) {
-  if (SPAWNABLE.has(model)) return model;
-  if (model === 'fable') return 'opus'; // fable derivations run headless as opus
-  return 'sonnet';
+  if (SPAWNABLE_GRADES.has(model)) return model;
+  if (model === 'grade-4') return 'grade-3'; // no headless fable alias
+  return 'grade-2';
+}
+// The Claude alias `claude -p --model` actually accepts for a (capped) grade.
+function spawnAliasFor(grade) {
+  return GRADE_SPAWN_ALIAS[capTier(grade)] || 'sonnet';
 }
 
 // The real model string to hand `claude -p --model` for a stamped tier: if the
@@ -49,7 +57,7 @@ function capTier(model) {
 function resolveSpawnModel(tier, effort, prefs) {
   const ex = store.resolveExec(tier, effort, prefs);
   if (ex.backend === 'codex') return ex.spawnId;      // the real gateway id
-  return capTier(tier);                                // Claude tier, headless-capped
+  return spawnAliasFor(tier);                          // Claude alias, headless-capped
 }
 
 // Is the `claude` CLI present to spawn? A headless drain is pointless without it,

--- a/plugins/sidequest/test/agentsync.test.js
+++ b/plugins/sidequest/test/agentsync.test.js
@@ -23,9 +23,9 @@ process.env.SIDEQUEST_DISCOVERY_DIRS = NO_CATALOG_DIR;
 
 const agentsync = require('../lib/agentsync.js');
 
-const TERRA = { slug: 'codex-gpt-5-6-terra', id: 'claude-codex-gpt-5.6-terra[1m]', label: 'GPT-5.6 Terra', suggestedTier: 'opus' };
-const SOL = { slug: 'codex-gpt-5-6-sol', id: 'claude-codex-gpt-5.6-sol[1m]', label: 'GPT-5.6 Sol', suggestedTier: 'fable' };
-const LUNA = { slug: 'codex-gpt-5-6-luna', id: 'claude-codex-gpt-5.6-luna[1m]', label: 'GPT-5.6 Luna', suggestedTier: 'haiku' };
+const TERRA = { slug: 'codex-gpt-5-6-terra', id: 'claude-codex-gpt-5.6-terra[1m]', label: 'GPT-5.6 Terra', suggestedTier: 'grade-3' };
+const SOL = { slug: 'codex-gpt-5-6-sol', id: 'claude-codex-gpt-5.6-sol[1m]', label: 'GPT-5.6 Sol', suggestedTier: 'grade-4' };
+const LUNA = { slug: 'codex-gpt-5-6-luna', id: 'claude-codex-gpt-5.6-luna[1m]', label: 'GPT-5.6 Luna', suggestedTier: 'grade-1' };
 
 function tmpDir() { return fs.mkdtempSync(path.join(os.tmpdir(), 'sq-agentsync-test-')); }
 function readDir(dir) { return fs.readdirSync(dir).filter((f) => f.toLowerCase().endsWith('.md')).sort(); }
@@ -205,6 +205,37 @@ test('multiple discovered models each get their four files', () => {
 /* -------------------------------------------------------------- *
  *  defaultAgentsDir never targets the real ~/.claude/agents under a test home
  * -------------------------------------------------------------- */
+
+
+test('temporary native agent returns an Agent-ready spawn spec and cleans up by name', () => {
+  const dir = tmpDir();
+  const created = agentsync.createNativeAgent({
+    ref: 'SQ-42', nonce: 'abcdef12', modelId: 'claude-codex-gpt-5.6-terra[1m]',
+    effort: 'medium', grade: 'grade-3', sessionId: 'session-42', tools: ['Read', 'Bash', 'SendMessage'],
+  }, { dir, waitMs: 0 });
+  assert.strictEqual(created.name, 'sidequest-native-sq-42-abcdef12');
+  assert.deepStrictEqual(created.spawn, { subagent_type: created.name, name: created.name, mode: 'bypassPermissions' });
+  const source = fs.readFileSync(created.file, 'utf8');
+  assert.match(source, /^model: claude-codex-gpt-5\.6-terra\[1m\]$/m);
+  assert.match(source, /^effort: medium$/m);
+  assert.match(source, /^tools: Read, Bash, SendMessage$/m);
+  assert.match(source, /^permissionMode: bypassPermissions$/m);
+  assert.ok(source.includes(agentsync.TEMP_MARKER));
+  assert.ok(source.includes('sidequest-native-grade: grade-3'));
+  assert.strictEqual(agentsync.cleanupNativeAgents({ name: created.name, dir }).removed, 1);
+  assert.ok(!fs.existsSync(created.file));
+});
+
+test('temporary native agent cleanup respects session boundaries and recovers stale files', () => {
+  const dir = tmpDir();
+  const a = agentsync.createNativeAgent({ ref: 'SQ-1', nonce: 'abcdef12', modelId: 'claude-a', effort: 'low', grade: 'grade-1', sessionId: 'one' }, { dir, waitMs: 0 });
+  const b = agentsync.createNativeAgent({ ref: 'SQ-2', nonce: 'abcdef34', modelId: 'claude-b', effort: 'high', grade: 'grade-2', sessionId: 'two' }, { dir, waitMs: 0 });
+  assert.strictEqual(agentsync.cleanupNativeAgents({ sessionId: 'one', dir }).removed, 1);
+  assert.ok(!fs.existsSync(a.file));
+  assert.ok(fs.existsSync(b.file));
+  assert.strictEqual(agentsync.cleanupNativeAgents({ dir, staleBefore: Date.now() + 1000 }).removed, 1);
+  assert.ok(!fs.existsSync(b.file));
+});
 
 test('defaultAgentsDir: SIDEQUEST_HOME redirects to <home>/agents, never the real dir (SQ-170)', () => {
   const realDir = path.join(os.homedir(), '.claude', 'agents');

--- a/plugins/sidequest/test/claim-effort-guard.test.js
+++ b/plugins/sidequest/test/claim-effort-guard.test.js
@@ -140,7 +140,7 @@ test('haiku-derived ticket (no effort axis): the guard stands down', () => {
   // Enable only haiku → every rung is haiku, effort null, so there is nothing to match.
   store.setModelPrefs({ routing: true, opus: false, sonnet: false, fable: false, haiku: true });
   try {
-    assert.strictEqual(derivedOf(ref).model, 'haiku', 'ticket should derive to haiku');
+    assert.strictEqual(derivedOf(ref).model, 'grade-1', 'ticket should derive to haiku');
     const claim = cliJson(['claim', ref, '--by', 'w1', '--effort', 'high']);
     assert.strictEqual(claim.ok, true, 'a haiku ticket has no effort to guard against');
   } finally {

--- a/plugins/sidequest/test/custom-models.test.js
+++ b/plugins/sidequest/test/custom-models.test.js
@@ -1,361 +1,67 @@
 'use strict';
-/**
- * Per-tier model backend (1.36.0): a ladder tier can be pointed at a discovered
- * Codex model, resolved at spawn. This file covers the store-level vocabulary,
- * resolveExec/resolveModelId, makeWorkedBy provenance, and the backward-compat
- * guarantee that the built-in ladder is unchanged. Catalog discovery integration
- * lives in discovery.test.js.
- * Run: node --test "plugins/sidequest/test/**\/*.test.js"
- */
 const test = require('node:test');
 const assert = require('node:assert');
 const os = require('os');
 const path = require('path');
 const fs = require('fs');
 
-process.env.SIDEQUEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'sq-tierbackend-'));
-const NO_CATALOG_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'sq-tb-nodiscovery-'));
-process.env.SIDEQUEST_DISCOVERY_DIRS = NO_CATALOG_DIR;
-
+process.env.SIDEQUEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'sq-grade-routing-'));
+process.env.SIDEQUEST_DISCOVERY_DIRS = fs.mkdtempSync(path.join(os.tmpdir(), 'sq-grade-catalog-'));
 const store = require('../lib/store.js');
-const {
-  routingLadder, getModelPrefs, setModelPrefs, getModelVocab, resolveModelId,
-  resolveExec, coerceModel, classifyModelFilter, makeWorkedBy,
-} = store;
 
-const TIER_ORDER = ['haiku', 'sonnet', 'opus', 'fable'];
-const EFFORT_MODELS = ['sonnet', 'opus', 'fable'];
-const ALL_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'];
+const GRADES = ['grade-1', 'grade-2', 'grade-3', 'grade-4'];
+const PREFS_FILE = path.join(process.env.SIDEQUEST_HOME, 'projects', 'model-prefs.json');
 
-function mkPrefs(tiers, efforts, bias) {
-  const p = { routingBias: bias };
-  for (const t of TIER_ORDER) p[t] = tiers.includes(t);
-  p.efforts = {};
-  for (const m of EFFORT_MODELS) {
-    const arr = Array.isArray(efforts) ? efforts : (efforts[m] || []);
-    const row = {};
-    for (const e of ALL_EFFORTS) row[e] = arr.includes(e);
-    p.efforts[m] = row;
-  }
-  return p;
-}
-
-const TERRA = { slug: 'codex-gpt-5-6-terra', id: 'claude-codex-gpt-5.6-terra[1m]', label: 'GPT-5.6 Terra', suggestedTier: 'opus' };
-const LUNA = { slug: 'codex-gpt-5-6-luna', id: 'claude-codex-gpt-5.6-luna[1m]', label: 'GPT-5.6 Luna', suggestedTier: 'haiku' };
-
-function seedCatalog(models) {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sq-tb-catalog-'));
-  fs.mkdirSync(path.join(dir, 'codex-gateway'), { recursive: true });
-  fs.writeFileSync(path.join(dir, 'codex-gateway', 'catalog.json'),
-    JSON.stringify({ schema: 2, source: 'codex-gateway', updatedAt: new Date().toISOString(), models }));
-  process.env.SIDEQUEST_DISCOVERY_DIRS = dir;
-  return dir;
-}
-function clearCatalog() { process.env.SIDEQUEST_DISCOVERY_DIRS = NO_CATALOG_DIR; }
-
-function rungs(ladder) {
-  const out = [];
-  for (const r of ladder) {
-    const s = `${r.model}.${r.effort}`;
-    if (!out.length || out[out.length - 1] !== s) out.push(s);
-  }
-  return out;
-}
-
-/* -------------------------------------------------------------- *
- *  vocabulary: tiers are always the four built-ins
- * -------------------------------------------------------------- */
-
-test('getModelVocab: exactly the four built-in tiers, five efforts', () => {
-  clearCatalog();
-  const v = getModelVocab(getModelPrefs());
-  assert.deepStrictEqual(v.models.slice().sort(), ['fable', 'haiku', 'opus', 'sonnet']);
-  assert.deepStrictEqual(v.efforts, ['low', 'medium', 'high', 'xhigh', 'max']);
+test('routing exposes canonical grade identities', () => {
+  assert.deepStrictEqual(store.getModelVocab().models, GRADES);
+  assert.strictEqual(store.coerceModel('grade-3'), 'grade-3');
+  assert.strictEqual(store.coerceModel('opus'), 'grade-3');
+  assert.strictEqual(store.coerceModel('complex'), 'grade-3');
+  assert.strictEqual(store.classifyModelFilter('fable'), 'grade-4');
 });
 
-test('coerceModel: one of the four tiers, else null (a Codex slug is NOT a tier)', () => {
-  assert.strictEqual(coerceModel('opus'), 'opus');
-  assert.strictEqual(coerceModel('OPUS'), 'opus');
-  assert.strictEqual(coerceModel('codex-gpt-5-6-terra'), null);
-  assert.strictEqual(coerceModel('any'), null);
-  assert.strictEqual(coerceModel(''), null);
+test('legacy provider, profile, effort and backend prefs migrate losslessly', () => {
+  fs.mkdirSync(path.dirname(PREFS_FILE), { recursive: true });
+  fs.writeFileSync(PREFS_FILE, JSON.stringify({
+    haiku: false, sonnet: true, opus: true, fable: false,
+    efforts: { sonnet: { low: false }, opus: { xhigh: false }, fable: { max: false } },
+    tierBackend: { opus: 'codex-gpt-5-6-terra' }, routingBias: 2,
+  }));
+  const prefs = store.getModelPrefs();
+  assert.strictEqual(prefs['grade-1'], false);
+  assert.strictEqual(prefs['grade-2'], true);
+  assert.strictEqual(prefs['grade-3'], true);
+  assert.strictEqual(prefs['grade-4'], false);
+  assert.strictEqual(prefs.efforts['grade-2'].low, false);
+  assert.strictEqual(prefs.efforts['grade-3'].xhigh, false);
+  assert.strictEqual(prefs.tierBackend['grade-3'], 'codex-gpt-5-6-terra');
+  assert.strictEqual(prefs.routingBias, 2);
+  const raw = JSON.parse(fs.readFileSync(PREFS_FILE, 'utf8'));
+  assert.deepStrictEqual(Object.keys(raw).filter((k) => /^grade-/.test(k)), GRADES);
+  for (const old of ['haiku', 'sonnet', 'opus', 'fable', 'routine', 'everyday', 'complex', 'frontier']) assert.ok(!(old in raw), old + ' must not persist');
+  assert.deepStrictEqual(Object.keys(raw.efforts).sort(), ['grade-2', 'grade-3', 'grade-4']);
+  assert.deepStrictEqual(Object.keys(raw.tierBackend).sort(), GRADES);
 });
 
-test('classifyModelFilter: any / unknown / a resolved tier', () => {
-  assert.strictEqual(classifyModelFilter(null), 'any');
-  assert.strictEqual(classifyModelFilter('none'), 'any');
-  assert.strictEqual(classifyModelFilter('opus'), 'opus');
-  assert.strictEqual(classifyModelFilter('nonsense'), 'unknown');
-});
-
-/* -------------------------------------------------------------- *
- *  resolveExec / resolveModelId
- * -------------------------------------------------------------- */
-
-test('resolveExec: a Claude-backed tier spawns the effort agent with model:<tier>', () => {
-  clearCatalog();
-  const prefs = getModelPrefs();
-  assert.deepStrictEqual(resolveExec('opus', 'high', prefs), {
-    agent: 'sidequest-exec-high', model: 'opus', spawnId: 'opus', backend: 'claude', slug: null,
-    runsModel: 'opus', runsLabel: 'opus',
+test('grade prefs round-trip and routing only emits grades', () => {
+  const saved = store.setModelPrefs({
+    'grade-2': false,
+    efforts: { 'grade-3': { high: false } },
+    tierBackend: { 'grade-4': 'claude' },
   });
+  assert.strictEqual(saved['grade-2'], false);
+  assert.strictEqual(saved.efforts['grade-3'].high, false);
+  for (const rung of store.routingLadder(saved)) assert.ok(GRADES.includes(rung.model));
+  const ticket = store.applyDerivedRouting({ complexity: 6 }, saved);
+  assert.ok(GRADES.includes(ticket.model));
+  assert.strictEqual(ticket.profile, ticket.model);
 });
 
-test('resolveExec: a Claude haiku tier has no effort agent (plain agent, model:haiku)', () => {
-  clearCatalog();
-  const ex = resolveExec('haiku', null, getModelPrefs());
-  assert.strictEqual(ex.agent, null);
-  assert.strictEqual(ex.model, 'haiku');
-});
-
-test('resolveExec: a Codex-backed tier spawns the slug agent with model:null + the real spawnId', () => {
-  seedCatalog([TERRA]);
-  const prefs = setModelPrefs({ tierBackend: { opus: TERRA.slug } });
-  const ex = resolveExec('opus', 'xhigh', prefs);
-  assert.strictEqual(ex.agent, 'sidequest-exec-codex-gpt-5-6-terra-xhigh');
-  assert.strictEqual(ex.model, null);
-  assert.strictEqual(ex.spawnId, TERRA.id);
-  assert.strictEqual(ex.backend, 'codex');
-});
-
-test('resolveExec: a Codex-backed HAIKU tier gets a fixed effort in its agent name', () => {
-  seedCatalog([LUNA]);
-  const prefs = setModelPrefs({ tierBackend: { haiku: LUNA.slug } });
-  const ex = resolveExec('haiku', null, prefs);
-  assert.strictEqual(ex.agent, 'sidequest-exec-codex-gpt-5-6-luna-medium');
-  assert.strictEqual(ex.spawnId, LUNA.id);
-});
-
-test('resolveModelId: a tier maps to itself, or to its mapped Codex id', () => {
-  seedCatalog([TERRA]);
-  const prefs = setModelPrefs({ tierBackend: { opus: TERRA.slug } });
-  assert.strictEqual(resolveModelId('sonnet', prefs), 'sonnet');
-  assert.strictEqual(resolveModelId('opus', prefs), TERRA.id);
-  assert.strictEqual(resolveModelId('nonsense', prefs), null);
-});
-
-/* -------------------------------------------------------------- *
- *  ladder is backend-agnostic (backward compat)
- * -------------------------------------------------------------- */
-
-test('regression: mapping a tier to Codex does NOT change the ladder shape', () => {
-  clearCatalog();
-  const base = rungs(routingLadder(mkPrefs(['sonnet', 'opus', 'fable'], ['high', 'xhigh'], 0)));
-  seedCatalog([TERRA]);
-  const prefs = setModelPrefs({ tierBackend: { opus: TERRA.slug } });
-  // routingLadder reads enabled tiers + efforts, not tierBackend
-  const mapped = rungs(routingLadder(Object.assign(mkPrefs(['sonnet', 'opus', 'fable'], ['high', 'xhigh'], 0), { tierBackend: prefs.tierBackend })));
-  assert.deepStrictEqual(mapped, base, 'ladder rungs still name tiers, unaffected by the backend map');
-});
-
-test('regression: the documented all-tiers/max-off/bias-0 snapshot is unchanged', () => {
-  clearCatalog();
-  const p = mkPrefs(['haiku', 'sonnet', 'opus', 'fable'], ['low', 'medium', 'high', 'xhigh'], 0);
-  const l = routingLadder(p);
-  assert.strictEqual(l.length, 10);
-  assert.strictEqual(l[0].model, 'haiku');
-  assert.strictEqual(l[9].model, 'fable');
-});
-
-/* -------------------------------------------------------------- *
- *  provenance
- * -------------------------------------------------------------- */
-
-test('makeWorkedBy: a built-in tier stamps with no prefs argument', () => {
-  const wb = makeWorkedBy({ model: 'opus', effort: 'high', by: 'x' });
-  assert.strictEqual(wb.model, 'opus');
-  assert.strictEqual(wb.effort, 'high');
-});
-
-test('makeWorkedBy: a discovered Codex slug is a valid provenance model', () => {
-  seedCatalog([TERRA]);
-  const wb = makeWorkedBy({ model: TERRA.slug, effort: 'high', by: 'x' });
-  assert.strictEqual(wb.model, TERRA.slug);
-});
-
-test('makeWorkedBy: throws on a model that is neither a tier nor a discovered slug', () => {
-  clearCatalog();
-  assert.throws(() => makeWorkedBy({ model: 'gpt-bogus', by: 'x' }), /invalid model/);
-});
-
-test('makeWorkedBy: no model -> null (a done with no --model carries no stamp)', () => {
-  assert.strictEqual(makeWorkedBy({ effort: 'high', by: 'x' }), null);
-});
-
-/* -------------------------------------------------------------- *
- *  applyDerivedRouting attaches a resolved exec
- * -------------------------------------------------------------- */
-
-test('a ticket read carries a resolved exec matching its stamped tier backend', () => {
-  seedCatalog([TERRA]);
-  const prefs = setModelPrefs({ tierBackend: { opus: TERRA.slug } });
-  // find the complexity that derives to opus
-  const ladder = routingLadder(prefs);
-  const opusC = ladder.findIndex((r) => r.model === 'opus') + 1;
-  assert.ok(opusC >= 1, 'some complexity derives to opus');
-  const t = store.applyDerivedRouting({ complexity: opusC }, prefs);
-  assert.strictEqual(t.model, 'opus');           // stamped by tier
-  assert.strictEqual(t.exec.backend, 'codex');   // but backed by Codex
-  assert.strictEqual(t.exec.agent, `sidequest-exec-codex-gpt-5-6-terra-${t.effort}`);
-  assert.strictEqual(t.exec.model, null);
-});
-
-/* -------------------------------------------------------------- *
- *  execution profiles (SQ-188): the neutral user-facing plan over
- *  the unchanged internal tier ladder
- * -------------------------------------------------------------- */
-
-const PROFILES = ['routine', 'everyday', 'complex', 'frontier'];
-const PROFILE_TIER = { routine: 'haiku', everyday: 'sonnet', complex: 'opus', frontier: 'fable' };
-
-// Reset the persisted prefs to the everything-on defaults with no backend map,
-// so each profile test starts from a known state (this file's tests share one
-// SIDEQUEST_HOME and setModelPrefs persists).
-function resetPrefs() {
-  const efforts = {};
-  for (const m of EFFORT_MODELS) {
-    efforts[m] = ALL_EFFORTS.reduce((o, e) => ((o[e] = true), o), {});
-  }
-  return setModelPrefs({
-    haiku: true, sonnet: true, opus: true, fable: true,
-    efforts,
-    tierBackend: { haiku: 'claude', sonnet: 'claude', opus: 'claude', fable: 'claude' },
-    routing: true, routingBias: 0,
-  });
-}
-
-test('profile vocabulary: four profiles, bidirectional tier mapping', () => {
-  assert.deepStrictEqual(store.EXECUTION_PROFILES, PROFILES);
-  assert.strictEqual(store.tierForProfile('everyday'), 'sonnet');
-  assert.strictEqual(store.tierForProfile('OPUS'), 'opus');      // a tier passes through
-  assert.strictEqual(store.tierForProfile('nonsense'), null);
-  assert.strictEqual(store.profileForTier('fable'), 'frontier');
-  assert.strictEqual(store.profileForTier('routine'), 'routine'); // a profile passes through
-  assert.strictEqual(store.profileForTier('nonsense'), null);
-});
-
-test('coerceModel: profile names resolve to their tier, old tier aliases unchanged', () => {
-  assert.strictEqual(coerceModel('routine'), 'haiku');
-  assert.strictEqual(coerceModel('EVERYDAY'), 'sonnet');
-  assert.strictEqual(coerceModel('complex'), 'opus');
-  assert.strictEqual(coerceModel('frontier'), 'fable');
-  for (const tier of TIER_ORDER) assert.strictEqual(coerceModel(tier), tier, `legacy alias ${tier}`);
-});
-
-test('classifyModelFilter: a profile name filters as its tier', () => {
-  assert.strictEqual(classifyModelFilter('complex'), 'opus');
-  assert.strictEqual(classifyModelFilter('routine'), 'haiku');
-  assert.strictEqual(classifyModelFilter('still-nonsense'), 'unknown');
-});
-
-test('getModelPrefs.profiles: default all-Claude view, tier prefs intact alongside', () => {
-  clearCatalog();
-  const prefs = resetPrefs();
-  assert.deepStrictEqual(Object.keys(prefs.profiles), PROFILES);
-  for (const p of PROFILES) {
-    const row = prefs.profiles[p];
-    assert.strictEqual(row.tier, PROFILE_TIER[p], `${p} tier`);
-    assert.strictEqual(row.enabled, true, `${p} enabled`);
-    assert.strictEqual(row.backend, 'claude', `${p} claude-backed by default`);
-    assert.strictEqual(row.runsModel, PROFILE_TIER[p], `${p} runs its own tier`);
-    assert.match(row.runsLabel, /^Claude /, `${p} human label`);
-  }
-  assert.strictEqual(prefs.profiles.routine.efforts, null, 'routine/haiku has no effort axis');
-  assert.deepStrictEqual(prefs.profiles.complex.efforts, prefs.efforts.opus, 'profile efforts mirror the tier row');
-  // The documented default ladder (all tiers, all efforts, bias 0) grouped by
-  // profile — including the evidence-supported sonnet/opus crossover at C4/C5.
-  assert.deepStrictEqual(prefs.profiles.routine.complexities, [1]);
-  assert.deepStrictEqual(prefs.profiles.everyday.complexities, [2, 3, 5]);
-  assert.deepStrictEqual(prefs.profiles.complex.complexities, [4, 6, 7]);
-  assert.deepStrictEqual(prefs.profiles.frontier.complexities, [8, 9, 10]);
-  assert.deepStrictEqual(prefs.profiles.frontier.range, [8, 10]);
-  // The tier-keyed shape is still fully present (nothing migrated away).
-  for (const tier of TIER_ORDER) assert.strictEqual(prefs[tier], true);
-  assert.ok(prefs.efforts && prefs.tierBackend, 'tier prefs remain alongside the profiles view');
-});
-
-test('getModelPrefs.profiles: a Codex-backed tier surfaces as that profile\'s resolved runtime', () => {
-  seedCatalog([TERRA]);
-  resetPrefs();
-  const prefs = setModelPrefs({ tierBackend: { opus: TERRA.slug } });
-  assert.strictEqual(prefs.profiles.complex.backend, 'codex');
-  assert.strictEqual(prefs.profiles.complex.runsModel, TERRA.slug);
-  assert.strictEqual(prefs.profiles.complex.runsLabel, TERRA.label);
-  // Effort matrix and the rest of the backend map are untouched by the view.
-  assert.strictEqual(prefs.tierBackend.opus, TERRA.slug);
-  assert.strictEqual(prefs.tierBackend.sonnet, 'claude');
-  assert.deepStrictEqual(Object.keys(prefs.efforts).sort(), EFFORT_MODELS.slice().sort());
-});
-
-test('setModelPrefs: profile-keyed patches translate to tier keys, nothing profile-shaped persists', () => {
-  seedCatalog([TERRA]);
-  resetPrefs();
-  // Enable/disable by profile.
-  let saved = setModelPrefs({ profiles: { everyday: false } });
-  assert.strictEqual(saved.sonnet, false, 'everyday:false disables sonnet');
-  assert.strictEqual(saved.profiles.everyday.enabled, false);
-  saved = setModelPrefs({ profiles: { everyday: true } });
-  assert.strictEqual(saved.sonnet, true);
-  // Runtime assignment by profile.
-  saved = setModelPrefs({ profiles: { complex: { backend: TERRA.slug } } });
-  assert.strictEqual(saved.tierBackend.opus, TERRA.slug);
-  assert.strictEqual(saved.profiles.complex.backend, 'codex');
-  saved = setModelPrefs({ profiles: { complex: { backend: 'claude' } } });
-  assert.strictEqual(saved.tierBackend.opus, 'claude');
-  // Profile names accepted as tierBackend keys too.
-  saved = setModelPrefs({ tierBackend: { frontier: TERRA.slug } });
-  assert.strictEqual(saved.tierBackend.fable, TERRA.slug);
-  saved = setModelPrefs({ tierBackend: { frontier: 'claude' } });
-  assert.strictEqual(saved.tierBackend.fable, 'claude');
-  // Per-profile effort rows reach the tier's matrix row.
-  saved = setModelPrefs({ profiles: { complex: { efforts: { low: false } } } });
-  assert.strictEqual(saved.efforts.opus.low, false);
-  assert.strictEqual(saved.efforts.sonnet.low, true, 'other rows untouched');
-  // The persisted file stays tier-keyed only: no profiles object, no profile keys.
-  const raw = JSON.parse(fs.readFileSync(
-    path.join(process.env.SIDEQUEST_HOME, 'projects', 'model-prefs.json'), 'utf8'));
-  assert.ok(!('profiles' in raw), 'no profiles object on disk');
-  for (const p of PROFILES) {
-    assert.ok(!(p in raw), `no top-level "${p}" key on disk`);
-    assert.ok(!(p in (raw.tierBackend || {})), `no "${p}" tierBackend key on disk`);
-  }
-  resetPrefs();
-});
-
-test('setModelPrefs: an explicit tier key beats a stale profile echo in the same patch', () => {
-  clearCatalog();
-  resetPrefs();
-  // A legacy-shaped full-object PUT can carry both the flipped tier boolean and
-  // the profiles view it was GET'd with — the explicit tier key must win.
-  const saved = setModelPrefs({ sonnet: false, profiles: { everyday: { enabled: true } } });
-  assert.strictEqual(saved.sonnet, false, 'explicit sonnet:false wins over the profile echo');
-  resetPrefs();
-});
-
-test('applyDerivedRouting: every routed ticket carries its neutral profile', () => {
-  clearCatalog();
-  const prefs = resetPrefs();
-  for (let c = 1; c <= 10; c++) {
-    const t = store.applyDerivedRouting({ complexity: c }, prefs);
-    assert.strictEqual(t.profile, store.profileForTier(t.model), `c${c} profile matches its routed tier`);
-    assert.ok(PROFILES.includes(t.profile), `c${c} profile is one of the four`);
-  }
-});
-
-test('applyDerivedRouting: a legacy no-complexity ticket keeps its tags but resolves profile + exec', () => {
-  seedCatalog([TERRA]);
-  resetPrefs();
-  const prefs = setModelPrefs({ tierBackend: { opus: TERRA.slug } });
-  const t = store.applyDerivedRouting({ model: 'opus', effort: 'high' }, prefs);
-  assert.strictEqual(t.model, 'opus', 'stored tag untouched');
-  assert.strictEqual(t.effort, 'high', 'stored effort untouched');
-  assert.strictEqual(t.profile, 'complex');
-  assert.strictEqual(t.exec.backend, 'codex', 'legacy ticket still resolves its Codex backend');
-  assert.strictEqual(t.exec.agent, 'sidequest-exec-codex-gpt-5-6-terra-high');
-  assert.strictEqual(t.exec.runsLabel, TERRA.label);
-  // No model at all -> no profile, no exec.
-  const bare = store.applyDerivedRouting({ title: 'x' }, prefs);
-  assert.strictEqual(bare.profile, null);
-  assert.ok(!bare.exec, 'no exec without a tier');
-  resetPrefs();
+test('deprecated aliases are accepted but canonical output stays grade-keyed', () => {
+  const saved = store.setModelPrefs({ profiles: { complex: { enabled: false, efforts: { low: false } } }, tierBackend: { frontier: 'claude' } });
+  assert.strictEqual(saved['grade-3'], false);
+  assert.strictEqual(saved.efforts['grade-3'].low, false);
+  const raw = JSON.parse(fs.readFileSync(PREFS_FILE, 'utf8'));
+  assert.ok(!('profiles' in raw));
+  assert.ok(!('complex' in raw.tierBackend));
 });

--- a/plugins/sidequest/test/discovery.test.js
+++ b/plugins/sidequest/test/discovery.test.js
@@ -39,9 +39,9 @@ function clearCatalog() {
   process.env.SIDEQUEST_DISCOVERY_DIRS = NO_CATALOG_DIR;
 }
 
-const SOL = { slug: 'codex-gpt-5-6-sol', id: 'claude-codex-gpt-5.6-sol[1m]', label: 'GPT-5.6 Sol', suggestedTier: 'fable' };
-const TERRA = { slug: 'codex-gpt-5-6-terra', id: 'claude-codex-gpt-5.6-terra[1m]', label: 'GPT-5.6 Terra', suggestedTier: 'opus' };
-const LUNA = { slug: 'codex-gpt-5-6-luna', id: 'claude-codex-gpt-5.6-luna[1m]', label: 'GPT-5.6 Luna', suggestedTier: 'haiku' };
+const SOL = { slug: 'codex-gpt-5-6-sol', id: 'claude-codex-gpt-5.6-sol[1m]', label: 'GPT-5.6 Sol', suggestedTier: 'grade-4' };
+const TERRA = { slug: 'codex-gpt-5-6-terra', id: 'claude-codex-gpt-5.6-terra[1m]', label: 'GPT-5.6 Terra', suggestedTier: 'grade-3' };
+const LUNA = { slug: 'codex-gpt-5-6-luna', id: 'claude-codex-gpt-5.6-luna[1m]', label: 'GPT-5.6 Luna', suggestedTier: 'grade-1' };
 
 /* -------------------------------------------------------------- *
  *  discoverExternalModels() in isolation
@@ -56,7 +56,7 @@ test('a valid schema-2 catalog resolves to [{slug,id,label,suggestedTier,source}
   seedCatalog([TERRA]);
   const got = discoverExternalModels();
   assert.strictEqual(got.length, 1);
-  assert.deepStrictEqual(got[0], { slug: TERRA.slug, id: TERRA.id, label: TERRA.label, suggestedTier: 'opus', source: 'codex-gateway' });
+  assert.deepStrictEqual(got[0], { slug: TERRA.slug, id: TERRA.id, label: TERRA.label, suggestedTier: 'grade-3', source: 'codex-gateway' });
 });
 
 test('suggestedTier missing/invalid -> null (still discovered)', () => {
@@ -68,12 +68,12 @@ test('suggestedTier missing/invalid -> null (still discovered)', () => {
 });
 
 test('legacy schema-1 anchor field is read as suggestedTier', () => {
-  seedCatalog([{ slug: 'codex-old', id: 'claude-codex-old[1m]', label: 'Old', anchor: 'opus' }], 1);
-  assert.strictEqual(discoverExternalModels()[0].suggestedTier, 'opus');
+  seedCatalog([{ slug: 'codex-old', id: 'claude-codex-old[1m]', label: 'Old', anchor: 'grade-3' }], 1);
+  assert.strictEqual(discoverExternalModels()[0].suggestedTier, 'grade-3');
 });
 
 test('label falls back to slug when absent', () => {
-  seedCatalog([{ slug: 'codex-nolabel', id: 'claude-codex-nolabel[1m]', suggestedTier: 'haiku' }]);
+  seedCatalog([{ slug: 'codex-nolabel', id: 'claude-codex-nolabel[1m]', suggestedTier: 'grade-1' }]);
   assert.strictEqual(discoverExternalModels()[0].label, 'codex-nolabel');
 });
 
@@ -106,42 +106,42 @@ test('no catalog -> discovered=[], every tier "claude", ladder built-in only', (
   clearCatalog();
   const prefs = getModelPrefs();
   assert.deepStrictEqual(prefs.discovered, []);
-  assert.deepStrictEqual(prefs.tierBackend, { opus: 'claude', sonnet: 'claude', haiku: 'claude', fable: 'claude' });
+  assert.deepStrictEqual(prefs.tierBackend, { 'grade-1': 'claude', 'grade-2': 'claude', 'grade-3': 'claude', 'grade-4': 'claude' });
   // every ladder rung is a built-in tier
   for (const rung of routingLadder(prefs)) {
-    assert.ok(['opus', 'sonnet', 'haiku', 'fable'].includes(rung.model), `rung ${rung.model} is a built-in`);
+    assert.ok(['grade-3', 'grade-2', 'grade-1', 'grade-4'].includes(rung.model), `rung ${rung.model} is a built-in`);
   }
 });
 
 test('mapping a tier to a discovered slug: resolveExec routes to its agent, ladder shape unchanged', () => {
   seedCatalog([TERRA, SOL, LUNA]);
   const prefs = setModelPrefs({ tierBackend: { opus: 'codex-gpt-5-6-terra' } });
-  assert.strictEqual(prefs.tierBackend.opus, 'codex-gpt-5-6-terra');
+  assert.strictEqual(prefs.tierBackend['grade-3'], 'codex-gpt-5-6-terra');
   assert.deepStrictEqual(prefs.tierBackendWarnings, []);
-  const ex = store.resolveExec('opus', 'high', prefs);
+  const ex = store.resolveExec('grade-3', 'high', prefs);
   assert.strictEqual(ex.agent, 'sidequest-exec-codex-gpt-5-6-terra-high');
   assert.strictEqual(ex.model, null);
   assert.strictEqual(ex.backend, 'codex');
   assert.strictEqual(ex.spawnId, TERRA.id);
   // sonnet still Claude
-  assert.strictEqual(store.resolveExec('sonnet', 'high', prefs).backend, 'claude');
+  assert.strictEqual(store.resolveExec('grade-2', 'high', prefs).backend, 'claude');
   // ladder still stamps the tier, not the backend slug
-  assert.strictEqual(routingLadder(prefs).find((r) => r.model !== 'haiku' && r.effort === 'high' && r.model === 'opus') !== undefined, true);
+  assert.strictEqual(routingLadder(prefs).find((r) => r.model !== 'grade-1' && r.effort === 'high' && r.model === 'grade-3') !== undefined, true);
 });
 
 test('stale mapping (slug not in catalog) falls back to Claude with a warning', () => {
   seedCatalog([TERRA]);
   const prefs = setModelPrefs({ tierBackend: { fable: 'codex-gone' } });
-  assert.ok(prefs.tierBackendWarnings.some((w) => w.includes('fable') && w.includes('codex-gone')));
-  assert.strictEqual(store.resolveExec('fable', 'high', prefs).backend, 'claude');
+  assert.ok(prefs.tierBackendWarnings.some((w) => w.includes('Grade 4') && w.includes('codex-gone')));
+  assert.strictEqual(store.resolveExec('grade-4', 'high', prefs).backend, 'claude');
 });
 
 test('clearing a mapping back to claude', () => {
   seedCatalog([TERRA]);
   setModelPrefs({ tierBackend: { opus: 'codex-gpt-5-6-terra' } });
   const prefs = setModelPrefs({ tierBackend: { opus: 'claude' } });
-  assert.strictEqual(prefs.tierBackend.opus, 'claude');
-  assert.strictEqual(store.resolveExec('opus', 'high', prefs).backend, 'claude');
+  assert.strictEqual(prefs.tierBackend['grade-3'], 'claude');
+  assert.strictEqual(store.resolveExec('grade-3', 'high', prefs).backend, 'claude');
 });
 
 test('a stale 1.35.0 customOverrides file is stripped on read, tierBackend defaults', () => {

--- a/plugins/sidequest/test/hooks.test.js
+++ b/plugins/sidequest/test/hooks.test.js
@@ -82,7 +82,7 @@ test('pre-tool hook forces bypass on sidequest worktree executors only', () => {
   const original = {
     subagent_type: 'sidequest-exec-high',
     isolation: 'worktree',
-    model: 'opus',
+    model: 'grade-3',
     name: 'sq36-srs-cards',
     prompt: 'work SQ-36',
   };

--- a/plugins/sidequest/test/ladder.test.js
+++ b/plugins/sidequest/test/ladder.test.js
@@ -15,15 +15,15 @@ process.env.SIDEQUEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'sq-ladder-te
 const store = require('../lib/store.js');
 const { routingLadder, deriveRouting, coerceComplexity, setModelPrefs } = store;
 
-const TIER_ORDER = ['haiku', 'sonnet', 'opus', 'fable'];
-const EFFORT_MODELS = ['sonnet', 'opus', 'fable']; // tiers that carry an effort row (haiku has none)
+const TIER_ORDER = ['grade-1', 'grade-2', 'grade-3', 'grade-4'];
+const EFFORT_MODELS = ['grade-2', 'grade-3', 'grade-4']; // tiers that carry an effort row (haiku has none)
 const EFFORT_ORDER = ['low', 'medium', 'high', 'xhigh']; // non-max scale
 const ALL_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'];
 // Per-tier base offsets mirroring store.js's LADDER_TIER_BASE (SQ-93: the
 // sonnet<->opus boundary keeps the old uniform gap of 2 — evidence-supported
 // crossover, unchanged — while the opus<->fable boundary widens to a gap of 4,
-// eliminating the previously-unsupported fable.low == opus.high tie).
-const TIER_BASE = { haiku: 0, sonnet: 2, opus: 4, fable: 8 };
+// eliminating the previously-unsupported grade-4.low == grade-3.high tie).
+const TIER_BASE = { 'grade-1': 0, 'grade-2': 2, 'grade-3': 4, 'grade-4': 8 };
 
 // All 15 non-empty tier subsets.
 const tierSubsets = [];
@@ -90,7 +90,7 @@ test('invariant sweep: 15 tier subsets x 5 effort subsets x 5 biases', () => {
           // No disabled tier emitted.
           assert.ok(tiers.includes(r.model), `${label} c${i + 1} model ${r.model} enabled`);
           // Effort null only on haiku; otherwise an enabled effort.
-          if (r.model === 'haiku') {
+          if (r.model === 'grade-1') {
             assert.strictEqual(r.effort, null, `${label} haiku effort null`);
           } else {
             assert.notStrictEqual(r.effort, null, `${label} non-haiku effort non-null`);
@@ -102,7 +102,7 @@ test('invariant sweep: 15 tier subsets x 5 effort subsets x 5 biases', () => {
         const nonMaxEfforts = efforts.filter((e) => e !== 'max');
         const maxInSequence = nonMaxEfforts.length === 0;
         const topTier = tiers[tiers.length - 1];
-        const hasMaxRung = efforts.includes('max') && !maxInSequence && topTier !== 'haiku';
+        const hasMaxRung = efforts.includes('max') && !maxInSequence && topTier !== 'grade-1';
 
         // Monotone capability as complexity rises (tie-break: higher tier ranks higher).
         for (let i = 1; i < 10; i++) {
@@ -136,13 +136,13 @@ test('invariant sweep: 15 tier subsets x 5 effort subsets x 5 biases', () => {
         // c1 -> cheapest rung: lowest tier, and its weakest enabled effort.
         const cheapTier = tiers[0];
         assert.strictEqual(ladder[0].model, cheapTier, `${label} c1 cheapest tier`);
-        if (cheapTier !== 'haiku') {
+        if (cheapTier !== 'grade-1') {
           const seqEfforts = maxInSequence ? efforts : nonMaxEfforts;
           assert.strictEqual(ladder[0].effort, seqEfforts[0], `${label} c1 weakest effort`);
         }
         // c10 -> top rung: top tier at its strongest available effort.
         assert.strictEqual(ladder[9].model, topTier, `${label} c10 top tier`);
-        if (topTier !== 'haiku') {
+        if (topTier !== 'grade-1') {
           const seqEfforts = maxInSequence ? efforts : nonMaxEfforts;
           const expectTopEff = hasMaxRung ? 'max' : seqEfforts[seqEfforts.length - 1];
           assert.strictEqual(ladder[9].effort, expectTopEff, `${label} c10 strongest effort`);
@@ -181,151 +181,151 @@ test('exact ladder: all tiers, max off, bias 0 (crossovers + tie-break, SQ-134 f
   // seq (score, tie->higher tier later): h0, sL2, sM3, sH4, oL4, sX5, oM5, oH6,
   // oX7, fL8, fM9, fH10, fX11 — N=13 bins; idx = min(12, floor((c-1)/10 * 13)),
   // with c=10 pinned to 12 (no max rung). Floor bucketing skips some rungs
-  // entirely (opus.low, opus.xhigh, fable.high never surface here) rather than
+  // entirely (grade-3.low, grade-3.xhigh, grade-4.high never surface here) rather than
   // round()'s interior-weighted spread — that's the intended bottom-weighting.
   // The sonnet<->opus boundary still ties/overlaps (sH4~oL4, sX5~oM5,
   // unchanged), but the opus<->fable boundary (SQ-93) no longer does:
-  // opus.xhigh(7) sits strictly below fable.low(8).
+  // grade-3.xhigh(7) sits strictly below grade-4.low(8).
   const prefs = mkPrefs(TIER_ORDER, ['low', 'medium', 'high', 'xhigh'], 0);
   const got = routingLadder(prefs).map((r) => `${r.model}.${r.effort}`);
   assert.deepStrictEqual(got, [
-    'haiku.null', 'sonnet.low', 'sonnet.medium', 'sonnet.high', 'sonnet.xhigh',
-    'opus.medium', 'opus.high', 'fable.low', 'fable.medium', 'fable.xhigh',
+    'grade-1.null', 'grade-2.low', 'grade-2.medium', 'grade-2.high', 'grade-2.xhigh',
+    'grade-3.medium', 'grade-3.high', 'grade-4.low', 'grade-4.medium', 'grade-4.xhigh',
   ]);
 });
 
-test('SQ-93 oracle: fable.low ranks strictly above opus.high (widened opus<->fable gap)', () => {
-  // Under the OLD uniform gap (tierRank*2), opus.high scored 2*2+2=6 and
-  // fable.low scored 3*2+0=6 — an exact tie, broken toward fable (the higher
-  // tier) so fable.low still landed just above opus.high in the merged order.
+test('SQ-93 oracle: grade-4.low ranks strictly above grade-3.high (widened opus<->fable gap)', () => {
+  // Under the OLD uniform gap (tierRank*2), grade-3.high scored 2*2+2=6 and
+  // grade-4.low scored 3*2+0=6 — an exact tie, broken toward fable (the higher
+  // tier) so grade-4.low still landed just above grade-3.high in the merged order.
   // The new per-tier base (opus=4, fable=8) pushes fable's floor strictly past
   // opus's ceiling (4+2=6 < 8+0=8): no tie, no ambiguity.
-  const fableLowScore = TIER_BASE.fable + EFFORT_ORDER.indexOf('low');
-  const opusHighScore = TIER_BASE.opus + EFFORT_ORDER.indexOf('high');
+  const fableLowScore = TIER_BASE["grade-4"] + EFFORT_ORDER.indexOf('low');
+  const opusHighScore = TIER_BASE["grade-3"] + EFFORT_ORDER.indexOf('high');
   assert.ok(
     fableLowScore > opusHighScore,
-    `fable.low score (${fableLowScore}) must be strictly above opus.high score (${opusHighScore})`
+    `grade-4.low score (${fableLowScore}) must be strictly above grade-3.high score (${opusHighScore})`
   );
 
   // End-to-end, through the actual merged sequence (opus+fable, all non-max
-  // efforts enabled, bias 0): opus.high must appear at a lower complexity than
-  // fable.low.
-  const prefs = mkPrefs(['opus', 'fable'], EFFORT_ORDER, 0);
+  // efforts enabled, bias 0): grade-3.high must appear at a lower complexity than
+  // grade-4.low.
+  const prefs = mkPrefs(['grade-3', 'grade-4'], EFFORT_ORDER, 0);
   const ladder = routingLadder(prefs).map((r) => `${r.model}.${r.effort}`);
-  const idxOpusHigh = ladder.indexOf('opus.high');
-  const idxFableLow = ladder.indexOf('fable.low');
-  assert.ok(idxOpusHigh !== -1, 'opus.high must appear in the ladder');
-  assert.ok(idxFableLow !== -1, 'fable.low must appear in the ladder');
+  const idxOpusHigh = ladder.indexOf('grade-3.high');
+  const idxFableLow = ladder.indexOf('grade-4.low');
+  assert.ok(idxOpusHigh !== -1, 'grade-3.high must appear in the ladder');
+  assert.ok(idxFableLow !== -1, 'grade-4.low must appear in the ladder');
   assert.ok(
     idxOpusHigh < idxFableLow,
-    `opus.high (c${idxOpusHigh + 1}) must rank below fable.low (c${idxFableLow + 1})`
+    `grade-3.high (c${idxOpusHigh + 1}) must rank below grade-4.low (c${idxFableLow + 1})`
   );
 });
 
-test('SQ-93 oracle: sonnet.xhigh still ties-or-adjacent opus.medium (unchanged crossover)', () => {
-  const sonnetXhighScore = TIER_BASE.sonnet + EFFORT_ORDER.indexOf('xhigh');
-  const opusMediumScore = TIER_BASE.opus + EFFORT_ORDER.indexOf('medium');
+test('SQ-93 oracle: grade-2.xhigh still ties-or-adjacent grade-3.medium (unchanged crossover)', () => {
+  const sonnetXhighScore = TIER_BASE["grade-2"] + EFFORT_ORDER.indexOf('xhigh');
+  const opusMediumScore = TIER_BASE["grade-3"] + EFFORT_ORDER.indexOf('medium');
   assert.ok(
     Math.abs(sonnetXhighScore - opusMediumScore) <= 1,
-    `sonnet.xhigh score (${sonnetXhighScore}) and opus.medium score (${opusMediumScore}) must tie or be adjacent`
+    `grade-2.xhigh score (${sonnetXhighScore}) and grade-3.medium score (${opusMediumScore}) must tie or be adjacent`
   );
   // This boundary is unchanged from the old formula: an exact tie, resolved to
   // the higher tier (opus) by the tie-break rule.
-  assert.strictEqual(sonnetXhighScore, opusMediumScore, 'sonnet.xhigh == opus.medium (exact tie, unchanged)');
+  assert.strictEqual(sonnetXhighScore, opusMediumScore, 'grade-2.xhigh == grade-3.medium (exact tie, unchanged)');
 
-  const prefs = mkPrefs(['sonnet', 'opus'], EFFORT_ORDER, 0);
+  const prefs = mkPrefs(['grade-2', 'grade-3'], EFFORT_ORDER, 0);
   const ladder = routingLadder(prefs).map((r) => `${r.model}.${r.effort}`);
-  const idxSonnetXhigh = ladder.indexOf('sonnet.xhigh');
-  const idxOpusMedium = ladder.indexOf('opus.medium');
+  const idxSonnetXhigh = ladder.indexOf('grade-2.xhigh');
+  const idxOpusMedium = ladder.indexOf('grade-3.medium');
   assert.ok(idxSonnetXhigh !== -1 && idxOpusMedium !== -1, 'both rungs appear in the ladder');
   assert.ok(
     idxOpusMedium >= idxSonnetXhigh,
-    `opus.medium (c${idxOpusMedium + 1}) must not rank below sonnet.xhigh (c${idxSonnetXhigh + 1})`
+    `grade-3.medium (c${idxOpusMedium + 1}) must not rank below grade-2.xhigh (c${idxSonnetXhigh + 1})`
   );
 });
 
 test('skipped middle tier keeps absolute ranks: haiku+opus, low+medium, bias 0 (SQ-134 floor bucketing)', () => {
-  // seq: h0, opus.low(4), opus.medium(5) — N=3 bins, no max rung (normalCount=10).
+  // seq: h0, grade-3.low(4), grade-3.medium(5) — N=3 bins, no max rung (normalCount=10).
   // idx = min(2, floor((c-1)/10 * 3)): bottom-weighted, so haiku (the cheapest
   // bucket) now claims 4 complexities instead of round()'s 3.
-  const prefs = mkPrefs(['haiku', 'opus'], ['low', 'medium'], 0);
+  const prefs = mkPrefs(['grade-1', 'grade-3'], ['low', 'medium'], 0);
   const got = routingLadder(prefs).map((r) => `${r.model}.${r.effort}`);
   assert.deepStrictEqual(got, [
-    'haiku.null', 'haiku.null', 'haiku.null', 'haiku.null', 'opus.low',
-    'opus.low', 'opus.low', 'opus.medium', 'opus.medium', 'opus.medium',
+    'grade-1.null', 'grade-1.null', 'grade-1.null', 'grade-1.null', 'grade-3.low',
+    'grade-3.low', 'grade-3.low', 'grade-3.medium', 'grade-3.medium', 'grade-3.medium',
   ]);
 });
 
 test('C9 max edge: haiku+opus all efforts, bias +5 gives max at 9 and 10 only', () => {
-  const ladder = routingLadder(mkPrefs(['haiku', 'opus'], ALL_EFFORTS, 5));
+  const ladder = routingLadder(mkPrefs(['grade-1', 'grade-3'], ALL_EFFORTS, 5));
   assert.deepStrictEqual(
     ladder.filter((r) => r.effort === 'max').map((r) => r.complexity),
     [9, 10]
   );
-  assert.strictEqual(ladder[8].model, 'opus');
+  assert.strictEqual(ladder[8].model, 'grade-3');
   // At bias +3 (and below), c9 stays off max.
-  const l3 = routingLadder(mkPrefs(['haiku', 'opus'], ALL_EFFORTS, 3));
+  const l3 = routingLadder(mkPrefs(['grade-1', 'grade-3'], ALL_EFFORTS, 3));
   assert.notStrictEqual(l3[8].effort, 'max');
   assert.strictEqual(l3[9].effort, 'max');
 });
 
 // SQ-134 acceptance tables: bottom-weighted floor bucketing, spec prefs
-// {haiku:false, sonnet:true, opus:true, fable:false,
-//  efforts:{sonnet:{low:false,medium:false},opus:{low:false,medium:false}}}
+// {'grade-1':false, 'grade-2':true, 'grade-3':true, 'grade-4':false,
+//  efforts:{'grade-2':{low:false,medium:false},'grade-3':{low:false,medium:false}}}
 // i.e. sonnet hi+xhi, opus hi+xhi+max (low/medium off on both, max defaults on).
-const SQ134_TICKET_EFFORTS = { sonnet: ['high', 'xhigh', 'max'], opus: ['high', 'xhigh', 'max'] };
+const SQ134_TICKET_EFFORTS = { 'grade-2': ['high', 'xhigh', 'max'], 'grade-3': ['high', 'xhigh', 'max'] };
 
 test('SQ-134 acceptance: neutral bias 0 (sonnet hi+xhi, opus hi+xhi+max)', () => {
-  const prefs = mkPrefs(['sonnet', 'opus'], SQ134_TICKET_EFFORTS, 0);
+  const prefs = mkPrefs(['grade-2', 'grade-3'], SQ134_TICKET_EFFORTS, 0);
   const got = routingLadder(prefs).map((r) => `${r.model}.${r.effort}`);
   assert.deepStrictEqual(got, [
-    'sonnet.high', 'sonnet.high', 'sonnet.high',
-    'sonnet.xhigh', 'sonnet.xhigh',
-    'opus.high', 'opus.high',
-    'opus.xhigh', 'opus.xhigh',
-    'opus.max',
+    'grade-2.high', 'grade-2.high', 'grade-2.high',
+    'grade-2.xhigh', 'grade-2.xhigh',
+    'grade-3.high', 'grade-3.high',
+    'grade-3.xhigh', 'grade-3.xhigh',
+    'grade-3.max',
   ]);
 });
 
-test('SQ-134 acceptance: frugal bias -5, gamma=3 (sonnet hi+xhi, opus hi+xhi+max) — opus.xhigh absent below max', () => {
-  const prefs = mkPrefs(['sonnet', 'opus'], SQ134_TICKET_EFFORTS, -5);
+test('SQ-134 acceptance: frugal bias -5, gamma=3 (sonnet hi+xhi, opus hi+xhi+max) — grade-3.xhigh absent below max', () => {
+  const prefs = mkPrefs(['grade-2', 'grade-3'], SQ134_TICKET_EFFORTS, -5);
   const got = routingLadder(prefs).map((r) => `${r.model}.${r.effort}`);
   assert.deepStrictEqual(got, [
-    'sonnet.high', 'sonnet.high', 'sonnet.high', 'sonnet.high', 'sonnet.high', 'sonnet.high',
-    'sonnet.xhigh', 'sonnet.xhigh',
-    'opus.high',
-    'opus.max',
+    'grade-2.high', 'grade-2.high', 'grade-2.high', 'grade-2.high', 'grade-2.high', 'grade-2.high',
+    'grade-2.xhigh', 'grade-2.xhigh',
+    'grade-3.high',
+    'grade-3.max',
   ]);
-  assert.ok(!got.includes('opus.xhigh'), 'opus.xhigh must not appear below the max rung at frugal bias');
+  assert.ok(!got.includes('grade-3.xhigh'), 'grade-3.xhigh must not appear below the max rung at frugal bias');
 });
 
 test('SQ-134 acceptance: full matrix, both tiers all four efforts + max, bias 0 — top normal rung at C9', () => {
-  const prefs = mkPrefs(['sonnet', 'opus'], ALL_EFFORTS, 0);
+  const prefs = mkPrefs(['grade-2', 'grade-3'], ALL_EFFORTS, 0);
   const got = routingLadder(prefs).map((r) => `${r.model}.${r.effort}`);
   assert.deepStrictEqual(got, [
-    'sonnet.low', 'sonnet.low', 'sonnet.medium', 'sonnet.high', 'opus.low',
-    'sonnet.xhigh', 'opus.medium', 'opus.high', 'opus.xhigh', 'opus.max',
+    'grade-2.low', 'grade-2.low', 'grade-2.medium', 'grade-2.high', 'grade-3.low',
+    'grade-2.xhigh', 'grade-3.medium', 'grade-3.high', 'grade-3.xhigh', 'grade-3.max',
   ]);
-  assert.strictEqual(got[0], 'sonnet.low', 'C1-2 land the cheapest rung');
-  assert.strictEqual(got[1], 'sonnet.low', 'C1-2 land the cheapest rung');
-  assert.strictEqual(got[8], 'opus.xhigh', 'C9 reaches the top NORMAL rung');
-  assert.strictEqual(got[9], 'opus.max', 'C10 is the sparing max rung');
+  assert.strictEqual(got[0], 'grade-2.low', 'C1-2 land the cheapest rung');
+  assert.strictEqual(got[1], 'grade-2.low', 'C1-2 land the cheapest rung');
+  assert.strictEqual(got[8], 'grade-3.xhigh', 'C9 reaches the top NORMAL rung');
+  assert.strictEqual(got[9], 'grade-3.max', 'C10 is the sparing max rung');
 });
 
 test('SQ-134 invariants: ticket prefs (sonnet hi+xhi, opus hi+xhi+max) hold at every bias -5..+5', () => {
   for (let bias = -5; bias <= 5; bias++) {
     const label = `bias ${bias}`;
-    const ladder = routingLadder(mkPrefs(['sonnet', 'opus'], SQ134_TICKET_EFFORTS, bias));
+    const ladder = routingLadder(mkPrefs(['grade-2', 'grade-3'], SQ134_TICKET_EFFORTS, bias));
     // C1 = cheapest enabled rung.
-    assert.strictEqual(ladder[0].model, 'sonnet', `${label} C1 cheapest tier`);
+    assert.strictEqual(ladder[0].model, 'grade-2', `${label} C1 cheapest tier`);
     assert.strictEqual(ladder[0].effort, 'high', `${label} C1 cheapest effort`);
     // C10 = max rung (hasMaxRung is true here: opus's row keeps max enabled).
-    assert.strictEqual(ladder[9].model, 'opus', `${label} C10 top tier`);
+    assert.strictEqual(ladder[9].model, 'grade-3', `${label} C10 top tier`);
     assert.strictEqual(ladder[9].effort, 'max', `${label} C10 hits the max rung`);
     // Monotone non-decreasing capability across C1..C10.
     const rank = (r) => {
       if (r.effort === 'max') return Infinity;
-      const base = r.model === 'opus' ? 4 : 2;
+      const base = r.model === 'grade-3' ? 4 : 2;
       return base + ['low', 'medium', 'high', 'xhigh'].indexOf(r.effort);
     };
     for (let i = 1; i < 10; i++) {
@@ -335,26 +335,26 @@ test('SQ-134 invariants: ticket prefs (sonnet hi+xhi, opus hi+xhi+max) hold at e
 });
 
 test('only max enabled: max carries the whole sequence, no extra sparing rung', () => {
-  const ladder = routingLadder(mkPrefs(['sonnet', 'opus'], ['max'], 0));
+  const ladder = routingLadder(mkPrefs(['grade-2', 'grade-3'], ['max'], 0));
   ladder.forEach((r) => assert.strictEqual(r.effort, 'max'));
-  assert.strictEqual(ladder[0].model, 'sonnet');
-  assert.strictEqual(ladder[9].model, 'opus');
+  assert.strictEqual(ladder[0].model, 'grade-2');
+  assert.strictEqual(ladder[9].model, 'grade-3');
 });
 
 test('haiku-only: 10 effort-null rungs, no max even when max enabled', () => {
   for (const bias of BIASES) {
-    const ladder = routingLadder(mkPrefs(['haiku'], ALL_EFFORTS, bias));
+    const ladder = routingLadder(mkPrefs(['grade-1'], ALL_EFFORTS, bias));
     ladder.forEach((r) => {
-      assert.strictEqual(r.model, 'haiku');
+      assert.strictEqual(r.model, 'grade-1');
       assert.strictEqual(r.effort, null);
     });
   }
 });
 
 test('single tier + single effort: constant ladder', () => {
-  const ladder = routingLadder(mkPrefs(['sonnet'], ['high'], -5));
+  const ladder = routingLadder(mkPrefs(['grade-2'], ['high'], -5));
   ladder.forEach((r) => {
-    assert.strictEqual(r.model, 'sonnet');
+    assert.strictEqual(r.model, 'grade-2');
     assert.strictEqual(r.effort, 'high');
   });
 });
@@ -364,7 +364,7 @@ test('empty prefs can never yield an empty ladder (defensive fallbacks)', () => 
   const ladder = routingLadder(prefs);
   assert.strictEqual(ladder.length, 10);
   ladder.forEach((r) => {
-    assert.strictEqual(r.model, 'sonnet');
+    assert.strictEqual(r.model, 'grade-2');
     assert.strictEqual(r.effort, 'medium');
   });
 });
@@ -375,7 +375,7 @@ test('setModelPrefs guards: refusing to disable every tier / every effort per ro
   for (const e of ALL_EFFORTS) allOff[e] = false; // flat keys broadcast "off" to every model row
   const saved = setModelPrefs(allOff);
   assert.ok(TIER_ORDER.some((t) => saved[t]), 'at least one tier stays enabled');
-  assert.strictEqual(saved.sonnet, true);
+  assert.strictEqual(saved['grade-2'], true);
   // Per-row guard: every model row keeps at least one effort, falling back to medium.
   for (const m of EFFORT_MODELS) {
     assert.ok(ALL_EFFORTS.some((e) => saved.efforts[m][e]), `${m} keeps an effort enabled`);
@@ -389,28 +389,28 @@ test('setModelPrefs guards: refusing to disable every tier / every effort per ro
   assert.strictEqual(setModelPrefs({ routingBias: 'garbage' }).routingBias, 0);
 });
 
-test('per-model efforts: disabling opus.medium drops that rung but keeps sonnet.medium', () => {
-  const prefs = mkPrefs(['sonnet', 'opus'], {
-    sonnet: ['low', 'medium', 'high', 'xhigh'],
-    opus: ['low', 'high', 'xhigh'], // medium excluded on opus only
+test('per-model efforts: disabling grade-3.medium drops that rung but keeps grade-2.medium', () => {
+  const prefs = mkPrefs(['grade-2', 'grade-3'], {
+    'grade-2': ['low', 'medium', 'high', 'xhigh'],
+    'grade-3': ['low', 'high', 'xhigh'], // medium excluded on opus only
   }, 0);
   const got = routingLadder(prefs).map((r) => `${r.model}.${r.effort}`);
-  assert.ok(got.includes('sonnet.medium'), 'sonnet.medium still routed');
-  assert.ok(!got.includes('opus.medium'), 'opus.medium never routed');
+  assert.ok(got.includes('grade-2.medium'), 'grade-2.medium still routed');
+  assert.ok(!got.includes('grade-3.medium'), 'grade-3.medium never routed');
   // opus's other rungs survive, so it's a targeted exclusion, not opus-wide.
-  assert.ok(got.includes('opus.low') && got.includes('opus.high'), 'opus keeps its other rungs');
+  assert.ok(got.includes('grade-3.low') && got.includes('grade-3.high'), 'opus keeps its other rungs');
 });
 
-test('per-model efforts: disabling fable.max (all tiers on) removes the sparing rung, c10 = top normal rung', () => {
+test('per-model efforts: disabling grade-4.max (all tiers on) removes the sparing rung, c10 = top normal rung', () => {
   const prefs = mkPrefs(TIER_ORDER, {
-    sonnet: ALL_EFFORTS,
-    opus: ALL_EFFORTS,
-    fable: ['low', 'medium', 'high', 'xhigh'], // top tier's row has max OFF
+    'grade-2': ALL_EFFORTS,
+    'grade-3': ALL_EFFORTS,
+    'grade-4': ['low', 'medium', 'high', 'xhigh'], // top tier's row has max OFF
   }, 0);
   const ladder = routingLadder(prefs);
   const got = ladder.map((r) => `${r.model}.${r.effort}`);
   assert.ok(!got.some((s) => s.endsWith('.max')), 'no max rung anywhere (top tier max off)');
-  assert.strictEqual(got[9], 'fable.xhigh', 'c10 lands the top normal rung');
+  assert.strictEqual(got[9], 'grade-4.xhigh', 'c10 lands the top normal rung');
 });
 
 test('migration: a legacy flat-key file on disk broadcasts into every model row', () => {
@@ -418,7 +418,7 @@ test('migration: a legacy flat-key file on disk broadcasts into every model row'
   fs.mkdirSync(path.dirname(file), { recursive: true });
   // Old shape: no `efforts` object, just the flat effort booleans.
   fs.writeFileSync(file, JSON.stringify({
-    haiku: true, sonnet: true, opus: true, fable: true,
+    'grade-1': true, 'grade-2': true, 'grade-3': true, 'grade-4': true,
     low: true, medium: false, high: true, xhigh: true, max: false,
     routing: true, routingBias: 0,
   }));
@@ -442,18 +442,18 @@ test('setModelPrefs: a flat-key patch broadcasts to every model row and writes n
   for (const e of ALL_EFFORTS) assert.ok(!(e in saved), `no flat "${e}" key on the written shape`);
 });
 
-test('setModelPrefs: per-row guard — disabling all of opus efforts leaves opus.medium on', () => {
+test('setModelPrefs: per-row guard — disabling all of opus efforts leaves grade-3.medium on', () => {
   // Start from a known-good baseline so sonnet/fable rows are unaffected by prior tests.
-  setModelPrefs({ efforts: { sonnet: ALL_EFFORTS.reduce((o, e) => ((o[e] = true), o), {}) } });
+  setModelPrefs({ efforts: { 'grade-2': ALL_EFFORTS.reduce((o, e) => ((o[e] = true), o), {}) } });
   const saved = setModelPrefs({
-    efforts: { opus: { low: false, medium: false, high: false, xhigh: false, max: false } },
+    efforts: { 'grade-3': { low: false, medium: false, high: false, xhigh: false, max: false } },
   });
-  assert.strictEqual(saved.efforts.opus.medium, true, 'opus falls back to medium');
+  assert.strictEqual(saved.efforts["grade-3"].medium, true, 'opus falls back to medium');
   for (const e of ['low', 'high', 'xhigh', 'max']) {
-    assert.strictEqual(saved.efforts.opus[e], false, `opus.${e} stays off`);
+    assert.strictEqual(saved.efforts["grade-3"][e], false, `grade-3.${e} stays off`);
   }
   // The nested patch touched only opus; sonnet keeps its full row.
-  assert.strictEqual(saved.efforts.sonnet.low, true, 'sonnet row untouched by the opus-only patch');
+  assert.strictEqual(saved.efforts["grade-2"].low, true, 'sonnet row untouched by the opus-only patch');
 });
 
 test('deriveRouting: shape and null on invalid complexity', () => {

--- a/plugins/sidequest/test/mcp.test.js
+++ b/plugins/sidequest/test/mcp.test.js
@@ -111,7 +111,7 @@ test('add enforces complexity + why and rejects direct model/effort', () => {
   // Missing complexity/why -> isError.
   assert.ok(callToolRaw('add', { title: 'no score' }).isError, 'missing complexity/why errors');
   assert.ok(callToolRaw('add', { title: 'bad', complexity: 3, why: 'too short' }).isError, 'a thin why errors');
-  assert.ok(callToolRaw('add', { title: 'direct', complexity: 3, why: 'x'.repeat(25), model: 'opus' }).isError, 'a direct model errors');
+  assert.ok(callToolRaw('add', { title: 'direct', complexity: 3, why: 'x'.repeat(25), model: 'grade-3' }).isError, 'a direct model errors');
 
   const out = callTool('add', { title: 'MCP add works', complexity: 3, why: 'a real motivation referencing the actual single-file change' });
   assert.strictEqual(out.ok, true);
@@ -132,7 +132,7 @@ test('claim -> comment -> done round-trips over the same store, tagged source mc
   assert.strictEqual(note.ok, true);
   assert.strictEqual(note.comment.source, 'mcp', 'MCP actions are tagged as background (not dashboard)');
 
-  const done = callTool('done', { ref, by: 'mcp-worker-1', model: 'sonnet', effort: 'high' });
+  const done = callTool('done', { ref, by: 'mcp-worker-1', model: 'grade-2', effort: 'high' });
   assert.strictEqual(done.ok, true);
   assert.strictEqual(done.ticket.status, 'done');
 });
@@ -147,7 +147,7 @@ test('claim requires a worker id (no shared-identity default)', () => {
 test('MCP claim rejects a generic executor for a Codex route', () => {
   const dir = seedCatalog([{ id: 'claude-codex-gpt-5.6-terra[1m]', slug: 'codex-gpt-5-6-terra', label: 'GPT-5.6 Terra' }]);
   try {
-    store.setModelPrefs({ routing: true, tierBackend: { sonnet: 'codex-gpt-5-6-terra' } });
+    store.setModelPrefs({ routing: true, tierBackend: { 'grade-2': 'codex-gpt-5-6-terra' } });
     const added = callTool('add', { title: 'Codex executor guard', complexity: 5, why: 'exercise MCP refusal when a generic executor claims a Codex-backed route' });
     const ticket = store.getTicket(store.ensureProject(PROJ).slug, added.ticket.ref);
     const rejected = callTool('claim', { ref: added.ticket.ref, by: 'mcp-generic', effort: ticket.effort, executor: `sidequest-exec-${ticket.effort}` });
@@ -157,7 +157,7 @@ test('MCP claim rejects a generic executor for a Codex route', () => {
   } finally {
     clearCatalog();
     seedCatalog([{ id: 'claude-codex-gpt-5.6-terra[1m]', slug: 'codex-gpt-5-6-terra', label: 'GPT-5.6 Terra' }]);
-    store.setModelPrefs({ routing: true, tierBackend: { sonnet: 'claude', opus: 'claude' } });
+    store.setModelPrefs({ routing: true, tierBackend: { 'grade-2': 'claude', 'grade-3': 'claude' } });
   }
 });
 
@@ -210,25 +210,25 @@ test('the real stdio server frames newline-delimited JSON-RPC', () => {
  * ------------------------------------------------------------------ */
 
 test('models tool surfaces the tier-backend map, detected models, and warnings', () => {
-  seedCatalog([{ slug: 'codex-terra', id: 'claude-codex-gpt-5.6-terra[1m]', label: 'Codex Terra', suggestedTier: 'opus' }]);
+  seedCatalog([{ slug: 'codex-terra', id: 'claude-codex-gpt-5.6-terra[1m]', label: 'Codex Terra', suggestedTier: 'grade-3' }]);
   try {
-    store.setModelPrefs({ tierBackend: { opus: 'codex-terra' } });
+    store.setModelPrefs({ tierBackend: { 'grade-3': 'codex-terra' } });
     const out = callTool('models', {});
     assert.ok(Array.isArray(out.discovered) && out.discovered.some((d) => d.slug === 'codex-terra'), 'discovered surfaces the catalog entry');
-    assert.strictEqual(out.tierBackend.opus, 'codex-terra', 'the tier backend map is reported');
-    assert.strictEqual(out.tierBackendResolved.opus.backend, 'codex', 'the resolved backend says opus runs on Codex');
-    assert.ok(out.ladder.some((r) => r.model === 'opus'), 'the ladder still names the built-in tier');
+    assert.strictEqual(out.tierBackend['grade-3'], 'codex-terra', 'the tier backend map is reported');
+    assert.strictEqual(out.tierBackendResolved["grade-3"].backend, 'codex', 'the resolved backend says opus runs on Codex');
+    assert.ok(out.ladder.some((r) => r.model === 'grade-3'), 'the ladder still names the built-in tier');
     assert.deepStrictEqual(out.tierBackendWarnings, [], 'no warnings when the mapping is live');
   } finally {
-    store.setModelPrefs({ tierBackend: { opus: 'claude' } });
+    store.setModelPrefs({ tierBackend: { 'grade-3': 'claude' } });
     clearCatalog();
   }
 });
 
 test('done stamps workedBy with a discovered Codex slug (provenance of what actually ran)', () => {
-  seedCatalog([{ slug: 'codex-terra', id: 'claude-codex-gpt-5.6-terra[1m]', suggestedTier: 'opus' }]);
+  seedCatalog([{ slug: 'codex-terra', id: 'claude-codex-gpt-5.6-terra[1m]', suggestedTier: 'grade-3' }]);
   try {
-    store.setModelPrefs({ tierBackend: { opus: 'codex-terra' } });
+    store.setModelPrefs({ tierBackend: { 'grade-3': 'codex-terra' } });
     const added = callTool('add', { title: 'codex provenance', complexity: 2, why: 'exercise done stamping workedBy with a discovered Codex model slug over MCP' });
     const ref = added.ticket.ref;
     callTool('claim', { ref, by: 'mcp-w-codex' });
@@ -236,7 +236,7 @@ test('done stamps workedBy with a discovered Codex slug (provenance of what actu
     assert.strictEqual(done.ok, true);
     assert.strictEqual(done.ticket.workedBy.model, 'codex-terra', 'the stamp records the Codex model that ran');
   } finally {
-    store.setModelPrefs({ tierBackend: { opus: 'claude' } });
+    store.setModelPrefs({ tierBackend: { 'grade-3': 'claude' } });
     clearCatalog();
   }
 });
@@ -249,17 +249,17 @@ test('ready with an unrecognized model errors instead of silently meaning "no fi
 });
 
 test('claim guard refusal names the Codex-backed executor for a Codex-mapped tier', () => {
-  seedCatalog([{ slug: 'codex-terra', id: 'claude-codex-gpt-5.6-terra[1m]', suggestedTier: 'opus' }]);
+  seedCatalog([{ slug: 'codex-terra', id: 'claude-codex-gpt-5.6-terra[1m]', suggestedTier: 'grade-3' }]);
   try {
     // Point the opus tier at Codex, then file a ticket that derives to opus and
     // claim it at the wrong effort. The refusal must name the Codex-backed exec.
-    const prefs = store.setModelPrefs({ routing: true, tierBackend: { opus: 'codex-terra' } });
+    const prefs = store.setModelPrefs({ routing: true, tierBackend: { 'grade-3': 'codex-terra' } });
     // find a complexity that derives to opus with a non-max effort
-    const rung = store.routingLadder(prefs).find((r) => r.model === 'opus' && r.effort && r.effort !== 'max');
+    const rung = store.routingLadder(prefs).find((r) => r.model === 'grade-3' && r.effort && r.effort !== 'max');
     assert.ok(rung, 'some complexity derives to opus');
     const added = callTool('add', { title: 'codex guard', complexity: rung.complexity, why: 'seed a ticket that derives to the opus tier so the claim guard refusal names the Codex-backed executor' });
     const ref = added.ticket.ref;
-    assert.strictEqual(added.ticket.model, 'opus', 'the ticket derived to the opus tier');
+    assert.strictEqual(added.ticket.model, 'grade-3', 'the ticket derived to the opus tier');
     assert.strictEqual(added.ticket.exec.backend, 'codex', 'and its exec is Codex-backed');
     const derivedEffort = added.ticket.effort;
     const wrong = store.VALID_EFFORTS.find((e) => e !== derivedEffort && e !== 'max');
@@ -268,7 +268,7 @@ test('claim guard refusal names the Codex-backed executor for a Codex-mapped tie
     assert.strictEqual(res.reason, 'effort_mismatch');
     assert.match(res.message, new RegExp(`sidequest-exec-codex-terra-${derivedEffort}`), 'names the Codex-backed executor');
   } finally {
-    store.setModelPrefs({ tierBackend: { opus: 'claude' } });
+    store.setModelPrefs({ tierBackend: { 'grade-3': 'claude' } });
     clearCatalog();
   }
 });

--- a/plugins/sidequest/test/reconcile.test.js
+++ b/plugins/sidequest/test/reconcile.test.js
@@ -67,7 +67,7 @@ test('a completed ticket is never auto-released, even if still registered', () =
   store.claimTicket(slug, a.ref, 'worker-done', { sessionId: 'sess-done' });
   // Finish WITHOUT passing the sessionId (simulates a done that forgot to thread
   // it) so the registry entry lingers — reconcile must still skip the done ticket.
-  store.completeTicket(slug, a.ref, 'worker-done', { model: 'sonnet', effort: 'high' });
+  store.completeTicket(slug, a.ref, 'worker-done', { model: 'grade-2', effort: 'high' });
   assert.strictEqual(store.getTicket(slug, a.ref).status, 'done');
 
   const res = store.reconcileSession('sess-done', { reason: 'session ended' });
@@ -121,7 +121,7 @@ test('reconciling an unknown session is a harmless no-op', () => {
 test('releaseTicket refuses a done ticket — a reconcile cannot un-complete finished work', () => {
   const a = addTicket('finished, then a stale release arrives');
   store.claimTicket(slug, a.ref, 'worker-r', { sessionId: 'sess-race' });
-  store.completeTicket(slug, a.ref, 'worker-r', { model: 'sonnet', effort: 'high' });
+  store.completeTicket(slug, a.ref, 'worker-r', { model: 'grade-2', effort: 'high' });
   assert.strictEqual(store.getTicket(slug, a.ref).status, 'done');
 
   // The exact call reconcileSession would make against a ticket it believed was

--- a/plugins/sidequest/test/server.test.js
+++ b/plugins/sidequest/test/server.test.js
@@ -116,10 +116,11 @@ test('findNewerInstall: repo-source checkout (non-semver dir name) never self-re
 test('dashboard presents execution profiles before advanced ladder controls', () => {
   const html = fs.readFileSync(path.join(__dirname, '..', 'dashboard', 'index.html'), 'utf8');
   assert.match(html, /id="routingProfiles"/);
-  assert.match(html, /id="editPlanBtn"/);
+  assert.doesNotMatch(html, /id="editPlanBtn"/);
+  assert.match(html, /routing-direct-controls/);
   assert.match(html, /<details class="advanced-routing"/);
   assert.ok(html.indexOf('id="routingProfiles"') < html.indexOf('id="ladderView"'));
-  assert.match(html, /modelPrefs\.profiles \|\| \{\}/);
+  assert.match(html, /var gradesView = modelPrefs\.profiles \|\| \{\}/);
   assert.match(html, /p\.complexities \|\| \[\]/);
 });
 

--- a/plugins/sidequest/test/work.test.js
+++ b/plugins/sidequest/test/work.test.js
@@ -37,10 +37,10 @@ function add(title, complexity, files) {
 }
 
 test('capTier keeps spawnable tiers and folds fable down to opus', () => {
-  assert.strictEqual(work.capTier('sonnet'), 'sonnet');
-  assert.strictEqual(work.capTier('opus'), 'opus');
-  assert.strictEqual(work.capTier('haiku'), 'haiku');
-  assert.strictEqual(work.capTier('fable'), 'opus');
+  assert.strictEqual(work.capTier('grade-2'), 'grade-2');
+  assert.strictEqual(work.capTier('grade-3'), 'grade-3');
+  assert.strictEqual(work.capTier('grade-1'), 'grade-1');
+  assert.strictEqual(work.capTier('grade-4'), 'grade-3');
 });
 
 test('planWork produces one spawn per wave-1 ready ticket, at its derived+capped tier, spawning nothing', () => {
@@ -56,12 +56,13 @@ test('planWork produces one spawn per wave-1 ready ticket, at its derived+capped
   assert.deepStrictEqual(refs, [a.ref, b.ref].sort(), 'wave 1 is the two disjoint tickets');
 
   for (const p of plan) {
-    assert.ok(['opus', 'sonnet', 'haiku'].includes(p.tier), 'tier is a spawnable alias');
+    assert.ok(['grade-3', 'grade-2', 'grade-1'].includes(p.tier), 'tier is a spawnable alias');
     assert.match(p.by, /^headless-sq-\d+-[0-9a-f]{6}$/, 'each run gets a unique worker id');
     // The argv is a real headless invocation carrying the model and JSON output;
     // the (large, multi-line) prompt rides separately, over stdin.
     assert.ok(p.argv.includes('-p'));
-    assert.strictEqual(p.argv[p.argv.indexOf('--model') + 1], p.tier);
+    const spawnAlias = { 'grade-1': 'haiku', 'grade-2': 'sonnet', 'grade-3': 'opus' }[p.tier];
+    assert.strictEqual(p.argv[p.argv.indexOf('--model') + 1], spawnAlias, 'argv --model is the grade\'s Claude spawn alias');
     assert.ok(p.argv.includes('--output-format') && p.argv.includes('json'));
     assert.ok(!p.argv.some((a) => /ONE ticket/.test(a)), 'the prompt is NOT in argv (it goes over stdin)');
     // The executor brief names the ticket and the claim-first protocol.
@@ -83,7 +84,7 @@ test('a fable-derived ticket plans as opus (headless cap)', () => {
   const { plan } = work.planWork(slug, { max: 10 });
   const entry = plan.find((p) => p.ref === t.ref);
   assert.ok(entry, 'the fable ticket is in the plan');
-  assert.strictEqual(entry.tier, 'opus', 'fable caps to opus for a spawnable headless model');
+  assert.strictEqual(entry.tier, 'grade-3', 'fable caps to opus for a spawnable headless model');
   store.setModelPrefs({ routing: true, opus: true, sonnet: true, haiku: true, fable: true });
 });
 
@@ -112,14 +113,14 @@ test('targeted plan keeps authoritative Codex model, fable provenance, and alway
     path.join(DISCOVERY_DIR, 'codex-gateway', 'catalog.json'),
     JSON.stringify({
       schema: 2, source: 'codex-gateway', updatedAt: new Date().toISOString(),
-      models: [{ slug: 'codex-target-sol', id: 'claude-codex-gpt-5.6-sol[1m]', label: 'Target Sol', suggestedTier: 'fable' }],
+      models: [{ slug: 'codex-target-sol', id: 'claude-codex-gpt-5.6-sol[1m]', label: 'Target Sol', suggestedTier: 'grade-4' }],
     }),
   );
   const prefs = store.setModelPrefs({
     routing: true, opus: false, sonnet: false, haiku: false, fable: true,
     tierBackend: { fable: 'codex-target-sol' },
   });
-  const rung = store.routingLadder(prefs).find((r) => r.model === 'fable' && r.effort !== 'max');
+  const rung = store.routingLadder(prefs).find((r) => r.model === 'grade-4' && r.effort !== 'max');
   assert.ok(rung);
   const created = store.createTicket(slug, {
     title: 'targeted Sol ticket', complexity: rung.complexity,
@@ -129,11 +130,11 @@ test('targeted plan keeps authoritative Codex model, fable provenance, and alway
   const planned = work.planTicket(slug, created.ref, { yolo: true });
   assert.strictEqual(planned.ok, true);
   assert.strictEqual(planned.item.backend, 'codex');
-  assert.strictEqual(planned.item.tier, 'fable', 'Codex-backed fable stays fable for done provenance');
+  assert.strictEqual(planned.item.tier, 'grade-4', 'Codex-backed fable stays fable for done provenance');
   assert.strictEqual(planned.item.spawnModel, 'claude-codex-gpt-5.6-sol[1m]');
   assert.ok(planned.item.argv.includes('--dangerously-skip-permissions'));
   assert.ok(!planned.item.argv.includes('--permission-mode'));
-  assert.match(planned.item.prompt, /--model fable/, 'executor closes with fable provenance');
+  assert.match(planned.item.prompt, /--model grade-4/, 'executor closes with grade-4 provenance');
 
   store.setModelPrefs({
     routing: true, opus: true, sonnet: true, haiku: true, fable: true,
@@ -181,7 +182,7 @@ test('a Codex-backed tier spawns the resolved id; the plan tier stays the built-
       schema: 2,
       source: 'codex-gateway',
       updatedAt: new Date().toISOString(),
-      models: [{ slug: 'codex-work-test', id: 'claude-codex-gpt-5.4[1m]', label: 'Codex Test', suggestedTier: 'opus' }],
+      models: [{ slug: 'codex-work-test', id: 'claude-codex-gpt-5.4[1m]', label: 'Codex Test', suggestedTier: 'grade-3' }],
     }),
   );
   const prefs = store.setModelPrefs({
@@ -190,7 +191,7 @@ test('a Codex-backed tier spawns the resolved id; the plan tier stays the built-
   });
   // Find a complexity that derives to the opus tier.
   const ladder = store.routingLadder(prefs);
-  const rung = ladder.find((r) => r.model === 'opus' && r.effort !== 'max');
+  const rung = ladder.find((r) => r.model === 'grade-3' && r.effort !== 'max');
   assert.ok(rung, 'sanity: some complexity derives to opus');
 
   const created = store.createTicket(slug, {
@@ -199,19 +200,19 @@ test('a Codex-backed tier spawns the resolved id; the plan tier stays the built-
     files: ['src/opus-tier-only.js'], source: 'cli',
   });
   const t = store.getTicket(slug, created.ref);
-  assert.strictEqual(t.model, 'opus', 'the ticket derived onto the opus tier');
+  assert.strictEqual(t.model, 'grade-3', 'the ticket derived onto the opus tier');
   assert.strictEqual(t.exec.backend, 'codex', 'and its resolved exec is Codex-backed');
 
-  const { plan } = work.planWork(slug, { max: 10, model: 'opus' });
+  const { plan } = work.planWork(slug, { max: 10, model: 'grade-3' });
   const entry = plan.find((p) => p.ref === t.ref);
   assert.ok(entry, 'the ticket is in the plan');
-  assert.strictEqual(entry.tier, 'opus', 'provenance/done stamping keeps the built-in tier');
+  assert.strictEqual(entry.tier, 'grade-3', 'provenance/done stamping keeps the built-in tier');
   assert.strictEqual(
     entry.argv[entry.argv.indexOf('--model') + 1],
     'claude-codex-gpt-5.4[1m]',
     'the spawned argv --model is the tier\'s resolved Codex id',
   );
-  assert.match(entry.prompt, /--model opus/, 'the done-command in the prompt stamps the tier for provenance');
+  assert.match(entry.prompt, /--model grade-3/, 'the done-command in the prompt stamps the grade for provenance');
 
   // Clean up so this doesn't leak into later tests in this file.
   store.setModelPrefs({ tierBackend: { opus: 'claude' } });


### PR DESCRIPTION
Routing identifiers are now provider-neutral grades (grade-1..grade-4) across storage, MCP, CLI, dashboard, and provenance, with lossless migration from tier-keyed prefs and deprecated input aliases. The main Routing view now edits runtimes directly per grade card with effort levels and band preference underneath; Edit plan is gone. Adds scripted temporary native executor agents for in-session dispatch and marks the README as under heavy construction.\n\nVerification: full suite 154/154; Playwright confirms grade cards update immediately when a runtime dropdown changes and persist after reload.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)