### PR TITLE
sidequest 1.38.2: effort follows the runtime, not the grade

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,7 +57,7 @@
       "name": "sidequest",
       "source": "./plugins/sidequest",
       "description": "A Trello-light quest log for Claude Code. Side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
-      "version": "1.38.1",
+      "version": "1.38.2",
       "author": {
         "name": "Eigenwise"
       },

--- a/plugins/sidequest/.claude-plugin/plugin.json
+++ b/plugins/sidequest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sidequest",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "description": "A Trello-light quest log for Claude Code. The side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
   "author": {
     "name": "Eigenwise",

--- a/plugins/sidequest/dashboard/index.html
+++ b/plugins/sidequest/dashboard/index.html
@@ -1070,13 +1070,11 @@
   // Gates the editor's Model picker and what the orchestrator is told to use;
   // an already-tagged ticket keeps showing its chip even if its tier is off.
   // `efforts` mirrors store.getModelPrefs's per-model matrix (SQ-129): one row
-  // per non-haiku tier, all effort levels on by default. Seeded up front so a
-  // toggle that fires before the first server sync lands still PUTs a well-formed
-  // nested object instead of an empty/partial one.
+  // per grade, all effort levels on by default. Grade 1 uses its row only while
+  // remapped to an effort-capable runtime, but retaining it makes remaps lossless.
   function defaultEffortsMatrix() {
     var out = {};
     MODELS.forEach(function (m) {
-      if (m.k === "grade-1") return;
       var row = {};
       EFFORTS.forEach(function (ef) { row[ef.k] = true; });
       out[m.k] = row;
@@ -1638,12 +1636,9 @@
     box.innerHTML = "";
     renderRoutingPlan();
     // Effort levels are a per-grade matrix (SQ-129: store.getModelPrefs's
-    // `efforts` object) — grade-3·medium can be off while grade-2·medium stays
-    // on. Rows are the non-grade-1 grades in MODELS order; grade-1 has no effort
-    // axis so it never gets a row. A grade whose runtime is disabled on its card
-    // dims here (its saved effort picks aren't lost, just deemphasized) rather
-    // than disappearing, so re-enabling the grade doesn't reset anything. The
-    // grade enable + runtime dropdown live on the routing cards above, not here.
+    // `efforts` object). Grade 1 gains a real row only while its runtime is
+    // remapped to Codex; Claude Haiku keeps its effort-null behavior. Rows whose
+    // runtime has no effort axis stay hidden without discarding saved choices.
     var grid = el("div", "effort-grid");
     var headRow = el("div", "eg-row eg-headrow");
     headRow.appendChild(el("span", "eg-label"));
@@ -1653,7 +1648,10 @@
       headRow.appendChild(h);
     });
     grid.appendChild(headRow);
-    MODELS.filter(function (m) { return m.k !== "grade-1"; }).forEach(function (m) {
+    MODELS.filter(function (m) {
+      var resolved = modelPrefs.tierBackendResolved || {};
+      return m.k !== "grade-1" || (resolved[m.k] && resolved[m.k].backend === "codex");
+    }).forEach(function (m) {
       var tierOn = modelEnabled(m.k);
       var row = el("div", "eg-row" + (tierOn ? "" : " dim"));
       var label = el("span", "eg-label");

--- a/plugins/sidequest/lib/store.js
+++ b/plugins/sidequest/lib/store.js
@@ -205,10 +205,12 @@ function coerceModel(v, _prefs) {
 // skill, not enforced here.
 const VALID_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'];
 
-// The tiers that carry an effort axis — every model except haiku (which has no
-// reasoning-effort support). model-prefs stores one effort row per tier here, so
-// a single (model, effort) combo like opus·medium can be excluded on its own.
-const EFFORT_MODELS = VALID_MODELS.filter((m) => m !== 'grade-1');
+// Every grade has a stored effort row so a grade can keep its picks while its
+// runtime changes. Grade 1 only *uses* that row when it resolves to an
+// effort-capable runtime (a Codex backend); Claude Haiku still has no effort
+// axis. Keeping the dormant row makes flipping Grade 1 Haiku → Codex → Haiku
+// lossless.
+const EFFORT_MODELS = VALID_MODELS.slice();
 
 function coerceEffort(v) {
   if (v == null) return null;
@@ -295,6 +297,15 @@ function resolveTierBackends(tierBackend) {
     }
   }
   return { byTier, warnings };
+}
+
+// Return true when this grade's resolved runtime accepts an effort level.
+// Grade 1 is Claude Haiku by default, but gets the same real effort axis as every
+// other grade when its runtime is remapped to Codex.
+function gradeHasEffort(grade, prefs) {
+  const byTier = prefs && (prefs.tierBackendResolved || resolveTierBackends(prefs.tierBackend).byTier);
+  const backend = byTier && byTier[grade];
+  return grade !== 'grade-1' || !!(backend && backend.backend === 'codex');
 }
 
 // The single spawn seam: given a stamped (tier, effort), return exactly how to
@@ -460,12 +471,13 @@ function routingLadder(prefs) {
   const tiers = [];
   for (const m of MODEL_CAPABILITY_ORDER) {
     if (prefs[m] === false) continue;
+    const hasEffort = gradeHasEffort(m, prefs);
     tiers.push({
       model: m,
       base: LADDER_TIER_BASE[m],
       tierRank: MODEL_CAPABILITY_ORDER.indexOf(m),
-      row: m === 'grade-1' ? null : builtinRow(m),
-      haiku: m === 'grade-1',
+      row: hasEffort ? builtinRow(m) : null,
+      haiku: !hasEffort,
     });
   }
   // Never return an empty ladder: fall back to Grade 2.
@@ -2166,7 +2178,7 @@ function deriveProfilesView(prefs) {
       backend: b.backend,
       runsModel: b.backend === 'codex' ? b.slug : GRADE_TIER[grade],
       runsLabel: b.backend === 'codex' ? (b.label || b.slug) : CLAUDE_TIER_LABELS[grade],
-      efforts: grade === 'grade-1' ? null : Object.assign({}, (prefs.efforts && prefs.efforts[grade]) || {}),
+      efforts: gradeHasEffort(grade, prefs) ? Object.assign({}, (prefs.efforts && prefs.efforts[grade]) || {}) : null,
       complexities,
       range: complexities.length ? [complexities[0], complexities[complexities.length - 1]] : null,
     };
@@ -2205,7 +2217,7 @@ function translateProfilePatch(patch) {
       if (v && typeof v === 'object') {
         if ('enabled' in v && !(grade in patch)) out[grade] = v.enabled !== false;
         if ('backend' in v && !(grade in explicitBackend)) out.tierBackend = Object.assign({}, out.tierBackend, { [grade]: v.backend });
-        if (grade !== 'grade-1' && v.efforts && typeof v.efforts === 'object') {
+        if (v.efforts && typeof v.efforts === 'object') {
           out.efforts = Object.assign({}, out.efforts, { [grade]: Object.assign({}, v.efforts, explicitEfforts[grade]) });
         }
       } else if (!(grade in patch)) out[grade] = v !== false;

--- a/plugins/sidequest/test/custom-models.test.js
+++ b/plugins/sidequest/test/custom-models.test.js
@@ -39,7 +39,7 @@ test('legacy provider, profile, effort and backend prefs migrate losslessly', ()
   const raw = JSON.parse(fs.readFileSync(PREFS_FILE, 'utf8'));
   assert.deepStrictEqual(Object.keys(raw).filter((k) => /^grade-/.test(k)), GRADES);
   for (const old of ['haiku', 'sonnet', 'opus', 'fable', 'routine', 'everyday', 'complex', 'frontier']) assert.ok(!(old in raw), old + ' must not persist');
-  assert.deepStrictEqual(Object.keys(raw.efforts).sort(), ['grade-2', 'grade-3', 'grade-4']);
+  assert.deepStrictEqual(Object.keys(raw.efforts).sort(), ['grade-1', 'grade-2', 'grade-3', 'grade-4']);
   assert.deepStrictEqual(Object.keys(raw.tierBackend).sort(), GRADES);
 });
 

--- a/plugins/sidequest/test/discovery.test.js
+++ b/plugins/sidequest/test/discovery.test.js
@@ -129,6 +129,23 @@ test('mapping a tier to a discovered slug: resolveExec routes to its agent, ladd
   assert.strictEqual(routingLadder(prefs).find((r) => r.model !== 'grade-1' && r.effort === 'high' && r.model === 'grade-3') !== undefined, true);
 });
 
+test('mapping grade 1 to Codex gives it effort rungs and preserves its effort prefs', () => {
+  seedCatalog([LUNA]);
+  const prefs = setModelPrefs({
+    tierBackend: { 'grade-1': LUNA.slug },
+    efforts: { 'grade-1': { low: false, medium: true, high: false, xhigh: false, max: false } },
+  });
+  assert.deepStrictEqual(prefs.profiles['grade-1'].efforts, { low: false, medium: true, high: false, xhigh: false, max: false });
+  const gradeOne = routingLadder(prefs).filter((r) => r.model === 'grade-1');
+  assert.ok(gradeOne.length > 0);
+  gradeOne.forEach((r) => assert.strictEqual(r.effort, 'medium'));
+  assert.strictEqual(store.resolveExec('grade-1', 'medium', prefs).agent, 'sidequest-exec-codex-gpt-5-6-luna-medium');
+
+  const haiku = setModelPrefs({ tierBackend: { 'grade-1': 'claude' } });
+  assert.strictEqual(haiku.profiles['grade-1'].efforts, null);
+  assert.strictEqual(haiku.efforts['grade-1'].medium, true, 'Haiku retains Grade 1 effort choices for a later remap');
+  routingLadder(haiku).filter((r) => r.model === 'grade-1').forEach((r) => assert.strictEqual(r.effort, null));
+});
 test('stale mapping (slug not in catalog) falls back to Claude with a warning', () => {
   seedCatalog([TERRA]);
   const prefs = setModelPrefs({ tierBackend: { fable: 'codex-gone' } });

--- a/plugins/sidequest/test/ladder.test.js
+++ b/plugins/sidequest/test/ladder.test.js
@@ -16,7 +16,7 @@ const store = require('../lib/store.js');
 const { routingLadder, deriveRouting, coerceComplexity, setModelPrefs } = store;
 
 const TIER_ORDER = ['grade-1', 'grade-2', 'grade-3', 'grade-4'];
-const EFFORT_MODELS = ['grade-2', 'grade-3', 'grade-4']; // tiers that carry an effort row (haiku has none)
+const EFFORT_MODELS = TIER_ORDER.slice(); // every grade stores a row; grade-1 uses it only with an effort-capable runtime
 const EFFORT_ORDER = ['low', 'medium', 'high', 'xhigh']; // non-max scale
 const ALL_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'];
 // Per-tier base offsets mirroring store.js's LADDER_TIER_BASE (SQ-93: the
@@ -49,8 +49,8 @@ const BIASES = [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5];
 // convenient mode the invariant sweep and oracles rely on) OR an object mapping
 // model -> array for per-model control (opus·medium excluded while sonnet keeps
 // it, etc.). Missing rows in the object form default to no efforts enabled.
-function mkPrefs(tiers, efforts, bias) {
-  const p = { routingBias: bias };
+function mkPrefs(tiers, efforts, bias, tierBackend) {
+  const p = { routingBias: bias, tierBackend: tierBackend || {} };
   for (const t of TIER_ORDER) p[t] = tiers.includes(t);
   p.efforts = {};
   for (const m of EFFORT_MODELS) {


### PR DESCRIPTION
Effort is a property of the assigned runtime, not the grade. Grade 1 had no effort axis because it defaults to Claude Haiku (no effort support); now, when Grade 1 is mapped to an effort-capable Codex model, it gains a real effort row in prefs, an editable effort-grid row on the dashboard, and per-effort C1-C2 ladder rungs. On Haiku it stays effort-null, and its saved effort picks are preserved for a later remap.\n\nVerification: 155/155 sidequest tests; Playwright confirms the Grade 1 effort row is absent on Haiku and appears when Grade 1 is remapped to GPT-5.6 Luna.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)