### PR TITLE
codex-gateway 0.5.1: compaction headroom for Codex models

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "codex-gateway",
       "source": "./plugins/codex-gateway",
       "description": "Your ChatGPT/Codex subscription models in Claude Code's /model picker. A local gateway routes claude-codex-* models to OpenAI's Codex backend (via claude-code-proxy) and everything else to api.anthropic.com, so you switch between Claude and GPT-5.x mid-session like any other model. No OpenAI API key.",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "author": {
         "name": "Eigenwise"
       },

--- a/plugins/codex-gateway/.claude-plugin/plugin.json
+++ b/plugins/codex-gateway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-gateway",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Your ChatGPT/Codex subscription models in Claude Code's /model picker. A local gateway routes claude-codex-* models to OpenAI's Codex backend (via claude-code-proxy) and everything else to api.anthropic.com, so you switch between Claude and GPT-5.x mid-session like any other model. No OpenAI API key.",
   "author": {
     "name": "Eigenwise",

--- a/plugins/codex-gateway/bin/codex-gateway.js
+++ b/plugins/codex-gateway/bin/codex-gateway.js
@@ -717,6 +717,20 @@ const DEFAULT_MODELS = [
   'gpt-5.3-codex', 'gpt-5.3-codex-spark', 'gpt-5.2',
 ];
 
+// The Codex backend accepts about 372k tokens, but compaction needs headroom
+// for the summary request. Claude Code uses max_input_tokens from gateway
+// discovery to decide when to compact, so advertise 85% of the real window.
+const CODEX_COMPACT_CONTEXT_WINDOW = 316200;
+
+function gatewayModel(id) {
+  return {
+    id: `${PREFIX}${id}`,
+    display_name: displayName(id),
+    type: 'model',
+    max_input_tokens: CODEX_COMPACT_CONTEXT_WINDOW,
+  };
+}
+
 // ------------------------------------------------------------ model catalog
 //
 // sidequest (same marketplace) auto-discovers Codex models by reading this
@@ -882,11 +896,7 @@ function createHostsBypassResolver({ resolve4, resolve6, ttlMs = 5 * 60 * 1000 }
 function runShim() {
   let modelCache = {
     at: 0,
-    data: DEFAULT_MODELS.map((id) => ({
-      id: `${PREFIX}${id}`,
-      display_name: displayName(id),
-      type: 'model',
-    })),
+    data: DEFAULT_MODELS.map(gatewayModel),
   };
   const counters = { models: 0, codex: 0, anthropic: 0 };
   // hostsDetected drives the DNS-bypass decision below regardless of whether
@@ -910,11 +920,7 @@ function runShim() {
     if (!Array.isArray(ids) || !ids.length) ids = DEFAULT_MODELS;
     modelCache = {
       at: Date.now(),
-      data: ids.map((id) => ({
-        id: `${PREFIX}${id}`,
-        display_name: displayName(id),
-        type: 'model',
-      })),
+      data: ids.map(gatewayModel),
     };
   }
   refreshModels();

--- a/plugins/codex-gateway/test/context-window.test.js
+++ b/plugins/codex-gateway/test/context-window.test.js
@@ -74,6 +74,7 @@ test('Codex discovery stays below the real backend context limit', async (t) => 
 
   const models = JSON.parse((await request(shimPort, 'GET', '/v1/models')).body);
   assert.equal(models.data[0].id, 'claude-codex-gpt-5.6-sol');
+  assert.equal(models.data[0].max_input_tokens, 316200);
   assert.equal(models.data[0].id.includes('[1m]'), false);
 
   await request(shimPort, 'POST', '/v1/messages', JSON.stringify({


### PR DESCRIPTION
On GPT-5.6 Sol, sessions ran to 100% context and then failed during compaction with a context-limit error, because Claude Code triggers compaction from the model's advertised max_input_tokens and the gateway advertised the full window. Advertise 316200 (~85% of the real ~372k window) so compaction fires with room left for its own summary request.\n\nVerification: 19/19 codex-gateway tests, including an HTTP-level check that /v1/models serves max_input_tokens: 316200.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)