### PR TITLE
sidequest 1.38.3: dedupe ladder rungs by resolved runtime

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,7 +57,7 @@
       "name": "sidequest",
       "source": "./plugins/sidequest",
       "description": "A Trello-light quest log for Claude Code. Side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
-      "version": "1.38.2",
+      "version": "1.38.3",
       "author": {
         "name": "Eigenwise"
       },

--- a/plugins/sidequest/.claude-plugin/plugin.json
+++ b/plugins/sidequest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sidequest",
-  "version": "1.38.2",
+  "version": "1.38.3",
   "description": "A Trello-light quest log for Claude Code. The side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
   "author": {
     "name": "Eigenwise",

--- a/plugins/sidequest/lib/store.js
+++ b/plugins/sidequest/lib/store.js
@@ -472,8 +472,10 @@ function routingLadder(prefs) {
   for (const m of MODEL_CAPABILITY_ORDER) {
     if (prefs[m] === false) continue;
     const hasEffort = gradeHasEffort(m, prefs);
+    const runtimeId = resolveExec(m, null, prefs).spawnId;
     tiers.push({
       model: m,
+      runtimeId,
       base: LADDER_TIER_BASE[m],
       tierRank: MODEL_CAPABILITY_ORDER.indexOf(m),
       row: hasEffort ? builtinRow(m) : null,
@@ -482,16 +484,41 @@ function routingLadder(prefs) {
   }
   // Never return an empty ladder: fall back to Grade 2.
   if (!tiers.length) {
-    tiers.push({ model: 'grade-2', base: LADDER_TIER_BASE['grade-2'], tierRank: MODEL_CAPABILITY_ORDER.indexOf('grade-2'), row: builtinRow('grade-2'), haiku: false });
+    tiers.push({ model: 'grade-2', runtimeId: resolveExec('grade-2', null, prefs).spawnId, base: LADDER_TIER_BASE['grade-2'], tierRank: MODEL_CAPABILITY_ORDER.indexOf('grade-2'), row: builtinRow('grade-2'), haiku: false });
   }
 
-  // ENUMERATE every enabled combo programmatically and score it by capability.
+  // Grades sharing one resolved runtime contribute one effort sequence. Keep the
+  // highest grade as the stamped provenance, use the cheapest grade's base for
+  // cross-runtime ranking, and union their enabled effort rows.
+  const runtimeGroups = [];
+  for (const tier of tiers) {
+    let group = runtimeGroups.find((candidate) => candidate.runtimeId === tier.runtimeId);
+    if (!group) {
+      group = { ...tier, row: tier.row ? { ...tier.row } : null, topBase: tier.base };
+      runtimeGroups.push(group);
+      continue;
+    }
+    group.topBase = Math.max(group.topBase, tier.base);
+    if (tier.tierRank > group.tierRank) {
+      group.model = tier.model;
+      group.tierRank = tier.tierRank;
+    }
+    if (tier.row) {
+      group.haiku = false;
+      group.row = group.row || {};
+      for (const effort of VALID_EFFORTS) {
+        group.row[effort] = group.row[effort] === true || tier.row[effort] === true;
+      }
+    }
+  }
+
+  // ENUMERATE every enabled resolved-runtime combo programmatically and score it by capability.
   // Haiku → a single effort-null rung; every other tier (built-in or custom) →
   // one rung per enabled non-max effort IN ITS OWN ROW (so opus·medium can be
   // excluded while sonnet·medium stays). A row with ONLY max enabled has max carry
   // that tier's sequence rungs (the per-tier maxInSequence fallback).
   const seq = [];
-  for (const tier of tiers) {
+  for (const tier of runtimeGroups) {
     if (tier.haiku) {
       seq.push({ model: 'grade-1', effort: null, tierRank: tier.tierRank, score: tier.base });
       continue;
@@ -521,11 +548,11 @@ function routingLadder(prefs) {
   // slug — a single deterministic top tier. It exists iff that tier's OWN row has
   // max enabled AND max isn't already carrying its sequence (only-max row); haiku
   // has no ·max, so there's none when it's the only/top tier.
-  let top = tiers[0];
-  for (const tier of tiers) {
-    if (tier.base > top.base
-      || (tier.base === top.base && tier.tierRank > top.tierRank)
-      || (tier.base === top.base && tier.tierRank === top.tierRank && String(tier.model) < String(top.model))) {
+  let top = runtimeGroups[0];
+  for (const tier of runtimeGroups) {
+    if (tier.topBase > top.topBase
+      || (tier.topBase === top.topBase && tier.tierRank > top.tierRank)
+      || (tier.topBase === top.topBase && tier.tierRank === top.tierRank && String(tier.model) < String(top.model))) {
       top = tier;
     }
   }

--- a/plugins/sidequest/test/discovery.test.js
+++ b/plugins/sidequest/test/discovery.test.js
@@ -43,9 +43,36 @@ const SOL = { slug: 'codex-gpt-5-6-sol', id: 'claude-codex-gpt-5.6-sol[1m]', lab
 const TERRA = { slug: 'codex-gpt-5-6-terra', id: 'claude-codex-gpt-5.6-terra[1m]', label: 'GPT-5.6 Terra', suggestedTier: 'grade-3' };
 const LUNA = { slug: 'codex-gpt-5-6-luna', id: 'claude-codex-gpt-5.6-luna[1m]', label: 'GPT-5.6 Luna', suggestedTier: 'grade-1' };
 
-/* -------------------------------------------------------------- *
- *  discoverExternalModels() in isolation
- * -------------------------------------------------------------- */
+test('shared runtime merges grade effort rows without duplicate or regressing runtime efforts', () => {
+  seedCatalog([TERRA]);
+  const efforts = {};
+  for (const grade of ['grade-1', 'grade-2', 'grade-3', 'grade-4']) {
+    efforts[grade] = { low: false, medium: false, high: false, xhigh: false, max: false };
+  }
+  efforts['grade-2'].high = true;
+  efforts['grade-2'].xhigh = true;
+  efforts['grade-3'].medium = true;
+  efforts['grade-3'].xhigh = true;
+  efforts['grade-3'].max = true;
+  const prefs = {
+    'grade-1': false, 'grade-2': true, 'grade-3': true, 'grade-4': false,
+    efforts, routingBias: 0,
+    tierBackend: { 'grade-2': TERRA.slug, 'grade-3': TERRA.slug },
+  };
+
+  const ladder = routingLadder(prefs);
+  const runtimePairs = ladder.map((r) => `${store.resolveModelId(r.model, prefs)}.${r.effort}`);
+  const effortRank = ['low', 'medium', 'high', 'xhigh', 'max'];
+  for (let i = 1; i < ladder.length; i++) {
+    assert.ok(effortRank.indexOf(ladder[i].effort) >= effortRank.indexOf(ladder[i - 1].effort));
+  }
+  assert.deepStrictEqual([...new Set(runtimePairs)], [
+    `${TERRA.id}.medium`, `${TERRA.id}.high`, `${TERRA.id}.xhigh`, `${TERRA.id}.max`,
+  ]);
+  assert.ok(ladder.every((r) => r.model === 'grade-3'), 'highest shared grade remains stamped for provenance');
+  clearCatalog();
+});
+
 
 test('no catalog anywhere -> []', () => {
   clearCatalog();


### PR DESCRIPTION
When two grades resolved to the same backend model (e.g. grade-2 and grade-3 both mapped to GPT-5.6 Terra), the ladder ranked rungs by abstract grade offset, producing a real capability drop on the shared model: Terra·xhigh at C5 followed by Terra·medium at C6. This groups tiers by resolved runtime id, collapses grades sharing a runtime into one ascending effort sequence (highest grade for provenance, unioned effort rows), and dedupes on (runtime, effort).\n\nVerification: 156/156 tests incl. a new shared-runtime regression test; a live ladder with grade-2+grade-3 on Terra now climbs Terra·medium (C5) -> Terra·high (C6) with no drop or duplicate.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)