### PR TITLE
sidequest 1.38.4: name temp native agents by runtime

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,7 +57,7 @@
       "name": "sidequest",
       "source": "./plugins/sidequest",
       "description": "A Trello-light quest log for Claude Code. Side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
-      "version": "1.38.3",
+      "version": "1.38.4",
       "author": {
         "name": "Eigenwise"
       },

--- a/plugins/sidequest/.claude-plugin/plugin.json
+++ b/plugins/sidequest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sidequest",
-  "version": "1.38.3",
+  "version": "1.38.4",
   "description": "A Trello-light quest log for Claude Code. The side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
   "author": {
     "name": "Eigenwise",

--- a/plugins/sidequest/bin/sidequest.js
+++ b/plugins/sidequest/bin/sidequest.js
@@ -961,6 +961,7 @@ function cmdNativeAgent(opts, positional) {
     modelId: resolved.spawnId,
     effort: ticket.effort,
     grade: ticket.model,
+    runtime: resolved.runsModel,
     sessionId,
   });
   process.stdout.write(JSON.stringify(Object.assign({ project: slug, ref: ticket.ref }, created), null, 2) + '\n');

--- a/plugins/sidequest/lib/agentsync.js
+++ b/plugins/sidequest/lib/agentsync.js
@@ -102,11 +102,38 @@ function renderBackendAgent(slug, id, effort) {
   });
 }
 
-function nativeAgentName(ref, nonce) {
-  const ticket = String(ref || 'ticket').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'ticket';
-  const suffix = String(nonce || crypto.randomBytes(4).toString('hex')).toLowerCase();
+function refToken(ref) {
+  return String(ref || 'ticket').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'ticket';
+}
+
+// Turn a resolved runtime (resolveExec's runsModel / slug, e.g.
+// "codex-gpt-5-6-luna" or the Claude alias "opus") into a filesystem-safe
+// DISPLAY token for the agent name: drop the noisy "codex-" catalog prefix so
+// the subagent card reads `gpt-5-6-luna`, and reduce to lowercase [a-z0-9-].
+// Returns '' when there's no runtime to show.
+function runtimeToken(runtime) {
+  return String(runtime || '')
+    .toLowerCase()
+    .replace(/^codex-/, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// Name the temporary native executor after the runtime it actually runs, so
+// Claude Code's subagent card shows the model (e.g.
+// sidequest-native-sq-198-gpt-5-6-luna) instead of a meaningless hex nonce. The
+// name STAYS TEMP_PREFIX-prefixed so cleanupNativeAgents still finds it, and the
+// runtime token is a display label only — routing ids stay neutral. A short hex
+// nonce is appended only to break a same-runtime collision for the same ref
+// (createNativeAgent supplies one when the base name is already on disk).
+function nativeAgentName(ref, runtime, nonce) {
+  const ticket = refToken(ref);
+  const token = runtimeToken(runtime);
+  const base = token ? `${TEMP_PREFIX}${ticket}-${token}` : `${TEMP_PREFIX}${ticket}`;
+  if (nonce == null || nonce === '') return base;
+  const suffix = String(nonce).toLowerCase();
   if (!/^[a-z0-9]{6,32}$/.test(suffix)) throw new Error('native agent nonce must be 6-32 lowercase alphanumeric characters.');
-  return `${TEMP_PREFIX}${ticket}-${suffix}`;
+  return `${base}-${suffix}`;
 }
 
 function nativeAgentFile(name, dir) {
@@ -151,12 +178,37 @@ function waitForNativeAgentReload(waitMs) {
 
 function createNativeAgent(spec, opts) {
   opts = opts || {};
+  spec = spec || {};
   const dir = opts.dir || defaultAgentsDir();
-  const name = nativeAgentName(spec && spec.ref, spec && spec.nonce);
-  const source = nativeAgentSource(Object.assign({}, spec, { name }));
   fs.mkdirSync(dir, { recursive: true });
-  const file = nativeAgentFile(name, dir);
-  fs.writeFileSync(file, source, { flag: 'wx' });
+  // The runtime label (resolveExec's runsModel, which is the catalog slug for a
+  // Codex tier or the Claude alias for a Claude tier) is what makes the name
+  // readable. An explicit spec.nonce forces that suffix; otherwise the name is
+  // the bare runtime-labeled base and a nonce is added only on collision.
+  const runtime = spec.runtime != null ? spec.runtime : spec.runsModel;
+  const explicitNonce = spec.nonce != null ? spec.nonce : null;
+  let name = nativeAgentName(spec.ref, runtime, explicitNonce);
+  if (explicitNonce == null && fs.existsSync(nativeAgentFile(name, dir))) {
+    // A same-runtime name for the same ref already exists on disk — disambiguate.
+    name = nativeAgentName(spec.ref, runtime, crypto.randomBytes(4).toString('hex'));
+  }
+  let file = nativeAgentFile(name, dir);
+  for (let attempt = 0; ; attempt++) {
+    const source = nativeAgentSource(Object.assign({}, spec, { name }));
+    try {
+      fs.writeFileSync(file, source, { flag: 'wx' });
+      break;
+    } catch (err) {
+      // Lost a create race against a parallel worker: try a fresh nonce. Only
+      // when we own the nonce (no explicit one was pinned by the caller).
+      if (err && err.code === 'EEXIST' && explicitNonce == null && attempt < 25) {
+        name = nativeAgentName(spec.ref, runtime, crypto.randomBytes(4).toString('hex'));
+        file = nativeAgentFile(name, dir);
+        continue;
+      }
+      throw err;
+    }
+  }
   waitForNativeAgentReload(opts.waitMs);
   return {
     name,

--- a/plugins/sidequest/lib/mcp.js
+++ b/plugins/sidequest/lib/mcp.js
@@ -501,6 +501,7 @@ const TOOLS = [
         modelId: resolved.spawnId,
         effort: ticket.effort,
         grade: ticket.model,
+        runtime: resolved.runsModel,
         tools: args.tools,
         sessionId: sessionOf(args),
       });

--- a/plugins/sidequest/test/agentsync.test.js
+++ b/plugins/sidequest/test/agentsync.test.js
@@ -207,23 +207,64 @@ test('multiple discovered models each get their four files', () => {
  * -------------------------------------------------------------- */
 
 
-test('temporary native agent returns an Agent-ready spawn spec and cleans up by name', () => {
+test('temporary native agent names itself after the resolved runtime (Codex slug), no hex nonce', () => {
   const dir = tmpDir();
   const created = agentsync.createNativeAgent({
-    ref: 'SQ-42', nonce: 'abcdef12', modelId: 'claude-codex-gpt-5.6-terra[1m]',
-    effort: 'medium', grade: 'grade-3', sessionId: 'session-42', tools: ['Read', 'Bash', 'SendMessage'],
+    ref: 'SQ-198', runtime: 'codex-gpt-5-6-luna', modelId: 'claude-codex-gpt-5.6-luna[1m]',
+    effort: 'medium', grade: 'grade-1', sessionId: 'session-198', tools: ['Read', 'Bash', 'SendMessage'],
   }, { dir, waitMs: 0 });
-  assert.strictEqual(created.name, 'sidequest-native-sq-42-abcdef12');
+  // The runtime shows in the card; the noisy "codex-" catalog prefix is dropped
+  // and there is no meaningless hex suffix.
+  assert.strictEqual(created.name, 'sidequest-native-sq-198-gpt-5-6-luna');
+  assert.ok(created.name.startsWith(agentsync.TEMP_PREFIX)); // still discoverable for cleanup
+  assert.ok(!/-[0-9a-f]{8}$/.test(created.name)); // no hex nonce tail
   assert.deepStrictEqual(created.spawn, { subagent_type: created.name, name: created.name, mode: 'bypassPermissions' });
   const source = fs.readFileSync(created.file, 'utf8');
-  assert.match(source, /^model: claude-codex-gpt-5\.6-terra\[1m\]$/m);
+  assert.match(source, /^model: claude-codex-gpt-5\.6-luna\[1m\]$/m);
   assert.match(source, /^effort: medium$/m);
   assert.match(source, /^tools: Read, Bash, SendMessage$/m);
   assert.match(source, /^permissionMode: bypassPermissions$/m);
   assert.ok(source.includes(agentsync.TEMP_MARKER));
-  assert.ok(source.includes('sidequest-native-grade: grade-3'));
+  assert.ok(source.includes('sidequest-native-grade: grade-1')); // routing id stays neutral
   assert.strictEqual(agentsync.cleanupNativeAgents({ name: created.name, dir }).removed, 1);
   assert.ok(!fs.existsSync(created.file));
+});
+
+test('a Claude-backed tier embeds its runtime alias in the name', () => {
+  const dir = tmpDir();
+  const created = agentsync.createNativeAgent({
+    ref: 'SQ-7', runtime: 'opus', modelId: 'opus',
+    effort: 'high', grade: 'grade-3', sessionId: 'session-7',
+  }, { dir, waitMs: 0 });
+  assert.strictEqual(created.name, 'sidequest-native-sq-7-opus');
+});
+
+test('same ref + same runtime collides safely: a nonce is appended, prefix cleanup still gets both', () => {
+  const dir = tmpDir();
+  const first = agentsync.createNativeAgent({
+    ref: 'SQ-198', runtime: 'codex-gpt-5-6-luna', modelId: 'claude-codex-gpt-5.6-luna[1m]',
+    effort: 'medium', grade: 'grade-1', sessionId: 'session-198',
+  }, { dir, waitMs: 0 });
+  const second = agentsync.createNativeAgent({
+    ref: 'SQ-198', runtime: 'codex-gpt-5-6-luna', modelId: 'claude-codex-gpt-5.6-luna[1m]',
+    effort: 'medium', grade: 'grade-1', sessionId: 'session-198',
+  }, { dir, waitMs: 0 });
+  assert.strictEqual(first.name, 'sidequest-native-sq-198-gpt-5-6-luna');
+  assert.notStrictEqual(second.name, first.name); // unique
+  assert.match(second.name, /^sidequest-native-sq-198-gpt-5-6-luna-[0-9a-f]{6,32}$/); // runtime kept, nonce appended
+  assert.ok(fs.existsSync(first.file) && fs.existsSync(second.file));
+  // Both are still TEMP_PREFIX-prefixed, so a by-session (prefix-scanning) cleanup takes both.
+  assert.strictEqual(agentsync.cleanupNativeAgents({ sessionId: 'session-198', dir }).removed, 2);
+  assert.ok(!fs.existsSync(first.file) && !fs.existsSync(second.file));
+});
+
+test('an explicit nonce is still honored (deterministic) and follows the runtime token', () => {
+  const dir = tmpDir();
+  const created = agentsync.createNativeAgent({
+    ref: 'SQ-42', runtime: 'codex-gpt-5-6-terra', nonce: 'abcdef12', modelId: 'claude-codex-gpt-5.6-terra[1m]',
+    effort: 'medium', grade: 'grade-3', sessionId: 'session-42',
+  }, { dir, waitMs: 0 });
+  assert.strictEqual(created.name, 'sidequest-native-sq-42-gpt-5-6-terra-abcdef12');
 });
 
 test('temporary native agent cleanup respects session boundaries and recovers stale files', () => {


### PR DESCRIPTION
The temporary native executor agent name embedded a random hex nonce, so Claude Code's subagent card read sidequest-native-sq-198-ff23136c with no signal about the model. It now embeds the resolved runtime (the catalog slug minus the codex- prefix, or the Claude alias): sidequest-native-sq-198-gpt-5-6-terra. Still TEMP_PREFIX-prefixed for cleanup discovery; a short nonce is appended only when a same-runtime name for the same ref already exists.\n\nVerification: 159/159 sidequest tests incl. runtime-in-name, Claude-alias, collision-nonce, and explicit-nonce cases; a live createNativeAgent call produced sidequest-native-sq-198-gpt-5-6-terra.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)