### PR TITLE
sidequest: ship executor permission allowlist (SQ-163)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(node plugins/sidequest/bin/sidequest.js:*)",
+      "Bash(node plugins/codex-gateway/bin/codex-gateway.js:*)",
+      "Bash(node --test:*)",
+      "Bash(git:*)"
+    ]
+  },
+  "enabledPlugins": {
+    "playwright@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,11 @@ desktop.ini
 .vscode/
 
 # Claude Code local settings + tool artifacts (never commit to this public repo)
-.claude/
+# — everything under .claude/ is ignored EXCEPT the shared project settings,
+# which ships the executor permission allowlist so background fan-out doesn't
+# prompt (SQ-163). settings.local.json (per-machine overrides) stays ignored.
+.claude/*
+!.claude/settings.json
 .playwright-mcp/
 
 # Node (only relevant if a plugin ever adds tooling)

--- a/plugins/sidequest/skills/sidequest/references/orchestration.md
+++ b/plugins/sidequest/skills/sidequest/references/orchestration.md
@@ -83,6 +83,26 @@ Caveats:
   research/debate/review; if you're spawning teammates anyway, they must still be `sidequest-exec`
   executors.
 
+## Background fan-out and the permission allowlist
+
+Passing `mode: "bypassPermissions"` on a spawn is necessary but **not currently sufficient** for
+background/fleet executors. Claude Code's background dispatch path doesn't honor
+`permissions.defaultMode=bypassPermissions`
+([anthropics/claude-code#59112](https://github.com/anthropics/claude-code/issues/59112)), and
+Agent-tool subagents can still prompt for Edit/Write even under a bypassed parent (#40241, #38026,
+#37442, #57118). So a background executor can fall back to `default` mode and prompt on every Bash
+call — and those prompts surface in the **lead** session, defeating hands-off fan-out.
+
+Until that upstream bug is fixed, background fan-out depends on a project **allowlist** in the
+consuming project's own committed `.claude/settings.json` — a `permissions.allow` list covering the
+exact commands executors run (`node <sidequest bin>`, `node --test`, `git`, and whatever the ticket
+work invokes). A subagent that fell back to `default` mode still won't prompt for that known set. This
+repo carries such a file as the worked example. `.claude/settings.json` is the *shared* (committed)
+settings; per-machine overrides go in `.claude/settings.local.json`, which stays git-ignored. If you
+add commands to the executor surface, extend the allowlist (the `fewer-permission-prompts` skill can
+generate it from transcripts). Never add `ask` rules — an `ask` forces a prompt even under a genuine
+bypass.
+
 ## Unattended draining (`sidequest work`)
 
 Interactive fan-out through the `sidequest-exec-*` agents is the default — it keeps the effort axis


### PR DESCRIPTION
Background/fleet executors don't reliably honor bypassPermissions (upstream claude-code#59112 plus subagent Edit/Write prompts #40241/#38026/#37442/#57118), so they fall back to default mode and prompt on every Bash call — and those prompts surface in the lead session, defeating hands-off fan-out.

Mitigation sidequest can own: a committed `.claude/settings.json` `permissions.allow` list covering the exact commands executors run (`node <sidequest bin>`, `node --test`, `git`, codex-gateway node calls), no `ask` rules. This repo's `.gitignore` blanket-ignored all of `.claude/`, so the shared file wasn't actually shipping; un-ignore just `.claude/settings.json` (settings.local.json stays ignored) and document the pattern in the sidequest orchestration guide.

Verification: 159/159 sidequest tests; settings.json is valid JSON with no `ask` rules; only the shared settings file is tracked, local artifacts remain ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)