### PR TITLE
sidequest 1.38.5: comment write integrity (SQ-173, SQ-174)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,7 +57,7 @@
       "name": "sidequest",
       "source": "./plugins/sidequest",
       "description": "A Trello-light quest log for Claude Code. Side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
-      "version": "1.38.4",
+      "version": "1.38.5",
       "author": {
         "name": "Eigenwise"
       },

--- a/plugins/sidequest/.claude-plugin/plugin.json
+++ b/plugins/sidequest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sidequest",
-  "version": "1.38.4",
+  "version": "1.38.5",
   "description": "A Trello-light quest log for Claude Code. The side issues you mention mid-task (\"oh, and the contact form doesn't send\") get captured as tickets on the spot, with any pasted images attached, and managed on a live, self-hosted Kanban dashboard that spans every project you work in.",
   "author": {
     "name": "Eigenwise",

--- a/plugins/sidequest/bin/sidequest.js
+++ b/plugins/sidequest/bin/sidequest.js
@@ -721,7 +721,12 @@ function cmdComment(opts, positional) {
     console.log(`✓ ${tag} comment added to ${res.ticket.ref} by "${by}"  — ${meta.name}`);
   } else {
     process.exitCode = 1;
-    const messages = { not_found: `no ticket "${idOrRef}" in ${meta.name}.`, empty: 'comment body cannot be empty.', busy: `${idOrRef} is locked right now — retry in a moment.` };
+    const messages = {
+      not_found: `no ticket "${idOrRef}" in ${meta.name}.`,
+      empty: 'comment body cannot be empty.',
+      too_long: `comment body is ${res.length} chars, over the ${res.max}-char cap — trim it or split into multiple comments (nothing was stored).`,
+      busy: `${idOrRef} is locked right now — retry in a moment.`,
+    };
     console.log(`✗ ${messages[res.reason] || 'comment failed: ' + res.reason}`);
   }
 }

--- a/plugins/sidequest/lib/server.js
+++ b/plugins/sidequest/lib/server.js
@@ -390,7 +390,9 @@ async function handle(req, res) {
     // so it doesn't notify them about their own message.
     const result = store.addComment(slug, cm[1], { by: body.by || 'you', body: body.body, kind: body.kind, source: 'dashboard' });
     if (!result.ok) {
-      sendJson(res, result.reason === 'not_found' ? 404 : 400, { error: result.reason });
+      const payload = { error: result.reason };
+      if (result.reason === 'too_long') { payload.max = result.max; payload.length = result.length; }
+      sendJson(res, result.reason === 'not_found' ? 404 : 400, payload);
       return;
     }
     sendJson(res, 201, result);

--- a/plugins/sidequest/lib/store.js
+++ b/plugins/sidequest/lib/store.js
@@ -1774,15 +1774,38 @@ function deleteStory(slug, idOrRef) {
  * ------------------------------------------------------------------ */
 
 const COMMENT_KINDS = ['comment', 'question'];
+// The hard storage cap for a single comment body. A body over this used to be
+// silently sliced to fit (SQ-173), so the tail of a long note vanished with no
+// signal to the caller. addComment now rejects an over-cap body instead of
+// truncating, so the write is either stored whole or fails loudly.
+const COMMENT_BODY_MAX = 4000;
 
 function newCommentId() {
   return 'c_' + Date.now().toString(36) + '_' + crypto.randomBytes(3).toString('hex');
 }
 
+// Comment bodies are stored verbatim except for control bytes that have no place
+// in prose. A raw NUL is the offender behind SQ-174: an author describing a
+// NUL-separated key (e.g. `source + '\0' + slug`) can smuggle a literal 0x00
+// into the body, and a NUL is a C-string terminator that silently truncates or
+// corrupts anything downstream that treats the body as a C string. Read back,
+// that lone NUL among hundreds of intact spaces looked like "a space turned into
+// \x00" (it never was: spaces are 0x20 and are left untouched). Strip the C0
+// control range and DEL, keeping only the whitespace that legitimately appears
+// in prose (tab, newline, carriage return). This runs at the one shared write
+// path, so the MCP `comment`/`ask` tools, the CLI `comment` command, and the
+// dashboard all get the same normalization.
+function stripControlChars(s) {
+  return s.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '');
+}
+
 function addComment(slug, idOrRef, fields) {
   fields = fields || {};
-  const body = String(fields.body || '').trim();
+  const body = stripControlChars(String(fields.body || '')).trim();
   if (!body) return { ok: false, reason: 'empty' };
+  if (body.length > COMMENT_BODY_MAX) {
+    return { ok: false, reason: 'too_long', max: COMMENT_BODY_MAX, length: body.length };
+  }
   const found = getTicket(slug, idOrRef);
   if (!found) return { ok: false, reason: 'not_found' };
   return withTicketLock(slug, found.id, () => {
@@ -1795,7 +1818,7 @@ function addComment(slug, idOrRef, fields) {
       id: newCommentId(),
       by: String(fields.by || 'agent'),
       kind,
-      body: body.slice(0, 4000),
+      body, // over-cap bodies are rejected above, never silently truncated
       source, // 'cli' (agent) or 'dashboard' (the human) — who needsResponse() listens for
       at: new Date().toISOString(),
     };

--- a/plugins/sidequest/test/mcp.test.js
+++ b/plugins/sidequest/test/mcp.test.js
@@ -137,6 +137,55 @@ test('claim -> comment -> done round-trips over the same store, tagged source mc
   assert.strictEqual(done.ticket.status, 'done');
 });
 
+test('SQ-174: a spaced comment round-trips with spaces intact and no NUL bytes', () => {
+  const added = callTool('add', { title: 'spaces intact', complexity: 1, why: 'exercise the MCP comment write path preserves internal spaces verbatim' });
+  const ref = added.ticket.ref;
+  const body = 'alpha  beta   gamma    delta'; // 2, 3, then 4 internal spaces
+  const posted = callTool('comment', { ref, body });
+  assert.strictEqual(posted.ok, true);
+  const back = callTool('comments', { ref });
+  const stored = back.comments[back.comments.length - 1].body;
+  assert.strictEqual(stored, body, 'the stored body equals the posted body verbatim');
+  assert.ok(!stored.includes('\u0000'), 'no NUL byte anywhere in the stored body');
+  assert.strictEqual((stored.match(/ /g) || []).length, 9, 'all nine internal spaces survive');
+});
+
+test('SQ-174: an author-supplied NUL (a NUL-separated key in prose) is stripped, not persisted', () => {
+  const added = callTool('add', { title: 'nul stripped', complexity: 1, why: 'a comment describing a NUL-separated dedup key must not persist the raw 0x00' });
+  const ref = added.ticket.ref;
+  // Mirrors the real SQ-171 note that misfired: `source + '\0' + slug`, but with
+  // a genuine 0x00 char between the quotes (as the reporter's body had).
+  const body = 'dedup key: source + \u0000 + slug (works)';
+  const posted = callTool('comment', { ref, body });
+  assert.strictEqual(posted.ok, true, 'the comment still stores (a lone control byte is normalized, not rejected)');
+  const back = callTool('comments', { ref });
+  const stored = back.comments[back.comments.length - 1].body;
+  assert.ok(!stored.includes('\u0000'), 'the raw NUL is gone from storage');
+  assert.strictEqual(stored, 'dedup key: source +  + slug (works)', 'only the NUL is removed; surrounding spaces stay');
+});
+
+test('SQ-173: an over-cap comment is rejected, not silently truncated', () => {
+  const added = callTool('add', { title: 'over cap', complexity: 1, why: 'confirm the MCP comment tool rejects a body past the 4k cap instead of cutting it' });
+  const ref = added.ticket.ref;
+
+  // A body one char over the cap must fail loudly, and nothing may be stored.
+  const tooLong = 'x'.repeat(4001);
+  const rejected = callTool('comment', { ref, body: tooLong });
+  assert.strictEqual(rejected.ok, false, 'the write is rejected');
+  assert.strictEqual(rejected.reason, 'too_long');
+  assert.strictEqual(rejected.max, 4000, 'the error names the cap');
+  assert.strictEqual(rejected.length, 4001, 'the error names the actual length');
+  const back = callTool('comments', { ref });
+  assert.strictEqual(back.comments.length, 0, 'no truncated comment leaked into storage');
+
+  // A body exactly at the cap still stores whole (the boundary is inclusive).
+  const atCap = 'y'.repeat(4000);
+  const ok = callTool('comment', { ref, body: atCap });
+  assert.strictEqual(ok.ok, true, 'a body exactly at the cap stores');
+  const back2 = callTool('comments', { ref });
+  assert.strictEqual(back2.comments[0].body.length, 4000, 'stored whole, not cut');
+});
+
 test('claim requires a worker id (no shared-identity default)', () => {
   const added = callTool('add', { title: 'needs by', complexity: 2, why: 'confirm the atomic-claim identity guard is enforced over MCP' });
   const res = callToolRaw('claim', { ref: added.ticket.ref });


### PR DESCRIPTION
**SQ-173** — a comment body over the 4000-char cap was silently truncated with `body.slice(0,4000)`, so the tail of a long note vanished with no signal (a design note lost a whole recommendation this way). `addComment` now rejects an over-cap body (`{ok:false, reason:'too_long', max, length}`); the CLI prints a clear over-cap message and exits 1, the dashboard POST returns 400 with `max`/`length`, and a body exactly at the cap still stores whole.

**SQ-174** — the reported "a space became a NUL byte" turned out to be a misdiagnosis: plain spaces (0x20) always stored verbatim on both the MCP and CLI paths. The single NUL in SQ-171's comment was a literal 0x00 the author wrote into a note about a NUL-separated dedup key. Still worth hardening — `addComment` now strips C0 control bytes + DEL (keeping tab/newline/CR) at the one shared write path, so MCP `comment`/`ask`, the CLI `comment` command, and the dashboard all normalize identically.

Verification: 162/162 tests (+3: spaces-intact round-trip, author-NUL stripped, over-cap rejected/at-cap stored). Reviewed all four call sites funnel through `addComment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)