### PR TITLE
fix(model-gateway): handle Artifact Unicode pattern rejected by Codex

### DIFF
--- a/docs/src/content/docs/getting-started/model-gateway.md
+++ b/docs/src/content/docs/getting-started/model-gateway.md
@@ -7,6 +7,8 @@ Model Gateway adds subscription-backed GPT and Grok models to Claude Code. Claud
 
 ## Install
 
+For GPT requests, the gateway omits the specific Unicode name pattern in Claude's `Artifact` tool schema that the Codex backend rejects as "not a regex". All other schema constraints remain. This relaxes the advertised name constraint; the tool may still reject invalid names when called. Claude requests pass through unchanged.
+
 Run these in Claude Code:
 
 ```text

--- a/plugins/model-gateway/lib/request-worker.js
+++ b/plugins/model-gateway/lib/request-worker.js
@@ -11,6 +11,7 @@ const net = require('node:net');
 const path = require('node:path');
 const zlib = require('node:zlib');
 const { writeFileAtomically } = require('./atomic-file.js');
+const { normalizeCodexArtifactSchema } = require('./tool-schema.js');
 const { createGatewayUsageEmitter, recordRequestBodyHighWater } = require('./usage-observability.js');
 const grokBackend = require('./grok-backend.js');
 const { fetchUrl } = require('./process-supervision.js');
@@ -1942,6 +1943,8 @@ function runWorker() {
               parsed.output_config = { ...(parsed.output_config || {}), effort: dispatchRoute.effort };
             }
             resolveCodexDeferredTools(parsed);
+            // Only normalize the known incompatible Artifact pattern on Codex.
+            normalizeCodexArtifactSchema(parsed.tools);
             // Non-Claude models call the plan-mode tools spuriously, and an
             // approved ExitPlanMode downgrades the session's permission mode
             // to acceptEdits instead of restoring it (anthropics/claude-code

--- a/plugins/model-gateway/lib/tool-schema.js
+++ b/plugins/model-gateway/lib/tool-schema.js
@@ -1,0 +1,19 @@
+'use strict';
+
+// Claude's Artifact name pattern requires Unicode-aware regex validation,
+// which the Codex backend rejects before the model can answer.
+const ARTIFACT_NAME_PATTERN = String.raw`^(?!__.*__$)[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}"\\./[\]]{1,200}$`;
+
+function normalizeCodexArtifactSchema(tools) {
+  if (!Array.isArray(tools)) return;
+  const visit = (node) => {
+    if (!node || typeof node !== 'object') return;
+    if (node.pattern === ARTIFACT_NAME_PATTERN) delete node.pattern;
+    for (const child of Object.values(node)) visit(child);
+  };
+  for (const tool of tools) {
+    if (tool?.name === 'Artifact') visit(tool.input_schema);
+  }
+}
+
+module.exports = { normalizeCodexArtifactSchema };

--- a/plugins/model-gateway/skills/model-gateway/SKILL.md
+++ b/plugins/model-gateway/skills/model-gateway/SKILL.md
@@ -193,6 +193,8 @@ agree).
 
 ## Failure modes worth knowing
 
+- **Artifact schema rejected as "not a regex"**: the Codex request path removes only the known incompatible Unicode name pattern from Claude's `Artifact` input schema. Other schema constraints and tools are retained, and Anthropic requests are unchanged. This relaxes the advertised name constraint for GPT models; invalid names can still be rejected when the tool executes.
+
 - **Every request fails after wiring**: a SessionStart hook can time out while it starts the shim. Claude Code cancels that hook, and a directly spawned supervisor can die with its process tree before it records an exit. Model Gateway launches the supervisor outside that tree and stops waiting before the hook budget, but if this is an older install or it still repeats, run
   `doctor`, check logs. Worst case `env --remove` restores stock behavior instantly.
 - **Codex sessions drop while this plugin's suite runs**: this version scopes fixture cleanup to

--- a/plugins/model-gateway/test/tool-schema.test.js
+++ b/plugins/model-gateway/test/tool-schema.test.js
@@ -1,0 +1,28 @@
+'use strict';
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { normalizeCodexArtifactSchema } = require('../lib/tool-schema.js');
+const pattern = String.raw`^(?!__.*__$)[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}"\\./[\]]{1,200}$`;
+
+test('normalizes the exact Artifact pattern in nested schema branches only', () => {
+  const tools = [{
+    name: 'Artifact',
+    input_schema: { anyOf: [{ properties: { name: { type: 'string', pattern } } }] },
+  }, { name: 'OtherTool', input_schema: { type: 'string', pattern } }];
+  const expected = structuredClone(tools);
+  delete expected[0].input_schema.anyOf[0].properties.name.pattern;
+  normalizeCodexArtifactSchema(tools);
+  assert.deepEqual(tools, expected);
+  normalizeCodexArtifactSchema(tools);
+  assert.deepEqual(tools, expected);
+});
+
+test('retains other patterns and tolerates absent schemas and tools', () => {
+  const tools = [null, { name: 'Artifact' }, {
+    name: 'Artifact', input_schema: { pattern: `${pattern}$` },
+  }];
+  const expected = structuredClone(tools);
+  normalizeCodexArtifactSchema(tools);
+  assert.deepEqual(tools, expected);
+  for (const value of [undefined, null, {}]) normalizeCodexArtifactSchema(value);
+});

--- a/plugins/model-gateway/test/tool-search.test.js
+++ b/plugins/model-gateway/test/tool-search.test.js
@@ -174,4 +174,31 @@ test('Codex tool search resolves references while Anthropic passthrough stays by
   assert.equal((await request(shimPort, '/v1/messages', anthropicRaw)).status, 200);
   assert.equal(forwardedToAnthropic, anthropicRaw);
   assert.equal(forwardedToCodex.length, 2);
+
+  const artifactPattern = String.raw`^(?!__.*__$)[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}"\\./[\]]{1,200}$`;
+  const artifact = {
+    name: 'Artifact',
+    description: 'Artifact fixture',
+    input_schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', pattern: artifactPattern, maxLength: 200 },
+        kind: { type: 'string', pattern: '^[a-z]+$' },
+      },
+      required: ['name'],
+    },
+  };
+  const artifactRequest = {
+    model: 'claude-gpt-6-astra[1m]',
+    max_tokens: 32,
+    messages: [{ role: 'user', content: 'Hello' }],
+    tools: [artifact, { ...artifact, name: 'OtherTool' }],
+  };
+  assert.equal((await request(shimPort, '/v1/messages', JSON.stringify(artifactRequest))).status, 200);
+  const normalized = structuredClone(artifact);
+  delete normalized.input_schema.properties.name.pattern;
+  assert.deepEqual(forwardedToCodex[2].tools, [normalized, artifactRequest.tools[1]]);
+  const artifactAnthropicRaw = JSON.stringify({ ...artifactRequest, model: 'claude-opus-4-8[1m]' }, null, 2);
+  assert.equal((await request(shimPort, '/v1/messages', artifactAnthropicRaw)).status, 200);
+  assert.equal(forwardedToAnthropic, artifactAnthropicRaw);
 });


### PR DESCRIPTION
Claude Code sessions using GPT-6 Astra can fail before answering with `400 Invalid schema for function 'Artifact': ... is not a 'regex'`. The Artifact name pattern uses Unicode property escapes that the backend schema validator rejects.

Normalize only that exact pattern, only within the Artifact input schema, and only on the Codex request path. Preserve other tools, other patterns, and the remaining schema constraints. Anthropic requests remain byte-identical. This deliberately relaxes the advertised name constraint rather than trying to translate its regex semantics; tool execution may still reject an invalid name.

Validation:
- Three tests pass via `node --test plugins/model-gateway/test/tool-schema.test.js plugins/model-gateway/test/tool-search.test.js`.
- Covers nested schemas, idempotence, missing schemas, preservation of unrelated patterns/tools, and HTTP routing with unchanged Anthropic passthrough.
- A local workaround using the same omission was verified against GPT-6 Astra: the previously rejected schema returned HTTP 200.

Reproduced with Model Gateway 0.50.5 and claude-code-proxy 0.1.37. No provider credentials or user session data are included.
